### PR TITLE
[BOJ] 1700 멀티탭 스케쥴링 😤😤

### DIFF
--- a/soomin/BOJ_1700.java
+++ b/soomin/BOJ_1700.java
@@ -1,0 +1,82 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class BOJ_1700 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        int[] electronics = new int[K];
+        List<Integer> multitap = new ArrayList<>();
+        for(int i = 0; i<K; i++){
+            electronics[i] = Integer.parseInt(st.nextToken());
+        }
+
+        //콘센트가 빈칸이면 꼽는다.
+        int index = 0;
+        while(true){
+            if(multitap.size() == N) break;
+            if(index == K) break;
+
+            if(multitap.contains(electronics[index])) {
+                index++;
+                continue;
+            }
+            multitap.add(electronics[index]);
+            index++;
+        }
+
+        //아니라면 하나를 빼고 꼽는다. => 뭘 빼야할까?
+        //이미 꼽혀있는 경우
+        int result = 0;
+        for(int i = index; i<K; i++){
+
+            boolean isPossible = false;
+
+            // 멀티탭에 꽂혀있으면
+            if(multitap.contains(electronics[i])) continue;
+
+            // 멀티탭을 비워줘야한다면? => 다시 안쓰일 친구 뽑거나 제일 나중에 다시쓰이는 친구 뽑기
+            Stack<Integer> stack = new Stack<>();
+            boolean[] visited = new boolean[N];
+            for(int j = i+1; j<K; j++){
+
+                if(stack.size() == N) break; // 현재 멀티탭에 있는 애들 다 나중에 다시 쓰임 ㅜ
+
+                for(int l = 0; l<N; l++){  // => 여길 잘 못 로직 짠 것같음. 멀티탭에 있는 애는 중복으로 stack에 넣을 필요가 없어서 방문 체크 해줄려고 한건디 먼가 이상함
+                    if(visited[l]) continue;
+                    if(multitap.get(l) == electronics[j]) stack.add(l);
+                    visited[l] = true;
+                }
+            }
+
+            if(stack.isEmpty()) {
+                multitap.remove(0);
+                multitap.add(electronics[i]); // 걍 아무거나 뽑으면 됨;
+            } else if(stack.size() == N) {
+                multitap.remove(stack.pop());
+                multitap.add(electronics[i]); // 제일 나중에 사용 되는 애 뽑기
+            } else { // 나중에 쓰일애말고 안쓰이는 애 (visited 안한 애) 뽑기 => 여길 잘 못 짠 것 같음
+                for(int j = 0; j<N; j++){
+                   if( visited[j] ) continue;
+
+                   multitap.remove(j);
+                   multitap.add(electronics[i]);
+                   break;
+                }
+            }
+            result++;
+        }
+
+    System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
예 저 못풀었어요 열받아요 처음에 뭔가 그리디 같았는데 진짜 그리디였네요
일단 세가지로 나눠서 생각하는 것까진 했습니다.
1. 이미 멀티탭에 꼽혀있을 경우!
2. 멀티탭이 차있을 경우 => 어떤 애를 뺄까?
3. 멀티탭이 비어있을 경우 => 이건 초기부분이라 while문으로 멀티탭이 비어있지 않을 때까지 돌려야겠다고 생각함

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/48270067/d70b470f-3ed1-46bd-a6a8-e5e7bef035d0)


## 📝 Review Note
생각은 했는데 구현을 못해서 아정이한테 물어봤습니다. 친절하게 알려줬지만 제가 구현 능력이 없나봅니다. 실패했습니다. 너무 스트레스 받아서 일단 올ㄹ리고 다음 문제로 넘어가겠습니다.

1. 멀티탭이 다 찰 때까지 반복문 돌리고 index를 증가한다.
2. index ~ K까지 입력받은 할일 순서대로 멀티탭을 탐색하면서 어떤 친구를 뺄지 본다. 1순위는 앞으로 더이상 안 쓸 친구다
3. 이 경우를 세가지로 봤는데 1. 앞으로 더이상 안나오는 친구 / 2. 멀티탭의 모든 전자기기들이 앞으로 더 나올 경우 / 3. 멀태탭의 전자기기 중 몇개만 더 나오고 몇개는 안나올 경우

이캐 짰는데 틀렷다람쥐
