### PR TITLE
[BOJ] 1916. 최소비용 구하기🚌

### DIFF
--- a/성영준/boj_1806_부분합.java
+++ b/성영준/boj_1806_부분합.java
@@ -1,0 +1,54 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class boj_1806_부분합 {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int s = Integer.parseInt(st.nextToken());
+
+        // 수열을 저장할 배열
+        int[] sequence = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++)
+            sequence[i] = Integer.parseInt(st.nextToken());
+
+        // 정답을 저장할 변수
+        // 불가능한 경우를 위해서 0으로 초기화 하였습니다.
+        int answer = 0;
+        // 부분합이 s 이상이 되는 시점의 길이 중 가장 짧은 길이를 저장할 변수
+        int shortest = Integer.MAX_VALUE;
+        // 부분합을 저장할 변수
+        int sum = 0;
+
+        // two pointer를 위한 변수들
+        int left = 0;
+        int right = 0;
+        while(true){
+            // 1. 부분합이 s보다 작은지 봅니다.
+            if(sum < s){
+                // 1-1. 작다면
+                // 2. 이미 우측의 pointer가 범위를 벗어났는지 확인합니다.
+                // 2-1. 벗어났다면 멈춥니다.
+                if(right == n)
+                    break;
+                // 2-2. 벗어나지 않았다면 부분합에 우측 값을 더하고 우측 pointer를 증가시킵니다.
+                sum += sequence[right++];
+            }else{
+                // 1-2. 크다면
+                // 3. 정답과 가장 짧은 길이를 저장할 변수를 갱신 합니다.
+                answer = shortest = Integer.min(shortest, right - left);
+                // 3-1. 만약 가장 짧은 길이가 1이면 멈춥니다.
+                if(answer == 1)
+                    break;
+                // 3-2. 1이 아니라면 부분합에 좌측 값을 빼고 좌측 pointer를 증가시킵니다.
+                sum -= sequence[left++];
+            }
+        }
+        System.out.println(answer);
+    }
+}

--- a/성영준/boj_1916_최소비용_구하기.java
+++ b/성영준/boj_1916_최소비용_구하기.java
@@ -1,0 +1,125 @@
+import java.io.*;
+import java.util.*;
+
+public class boj_1916_최소비용_구하기 {
+    static class Bus implements Comparable<Bus> {
+        int station;
+        int cost;
+
+        /**
+         * 버스 정보를 가지고 있는 객체
+         * @param station 도착지(도시)
+         * @param cost 버스 비용
+         */
+        public Bus(int station, int cost) {
+            this.station = station;
+            this.cost = cost;
+        }
+
+        /**
+         * 낮은 비용을 우선시 하여 비교하는 함수
+         * @param o the object to be compared.
+         * @return 낮은 비용
+         */
+        @Override
+        public int compareTo(Bus o) {
+            return cost - o.cost;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int n = Integer.parseInt(br.readLine());
+        int m = Integer.parseInt(br.readLine());
+
+        // 도시별 이동 비용을 저장할 인접 배열
+        // 인접배열을 선택한 이유 : 출발지와 도착지가 중복되는 버스가 존재할 가능성이 있음
+        int[][] cities = new int[n + 1][n + 1];
+        // 낮은 비용을 우선 시 하기 때문에 가장 큰 값으로 비용 초기화
+        for (int i = 1; i <= n; i++)
+            Arrays.fill(cities[i], Integer.MAX_VALUE);
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+
+            // 값이 존재할 경우 작은 값으로 저장하여 중복 제거
+            cities[from][to] = Integer.min(cities[from][to], cost);
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        System.out.println(dijkstra(start, end, n, cities));
+    }
+
+    /**
+     * 다익스트라
+     * @param start 시작 도시
+     * @param end 도착 도시
+     * @param n 도시의 수
+     * @param cities 도시별 이동 비용을 담은 배열
+     * @return 시작 도시부터 도착 도시까지의 최저 이동 비용
+     */
+    private static int dijkstra(int start, int end, int n, int[][] cities) {
+        // 낮은 비용을 갱신하기 위한 우선순위 큐
+        Queue<Bus> pq = new PriorityQueue<>();
+        // 비용이 정해진 도시의 재방문을 방지하기 위한 배열
+        boolean[] visited = new boolean[n + 1];
+
+        // 도시별 최저 도착 비용을 저장하기 위한 배열
+        int[] costs = new int[n + 1];
+        // 마찬가지로 최저 비용을 우선시 하기 때문에 최대 비용으로 초기화
+        Arrays.fill(costs, Integer.MAX_VALUE);
+
+        // 1. 시작 도시부터 출발
+        costs[start] = 0;
+        pq.add(new Bus(start, 0));
+
+        while (!pq.isEmpty()) {
+            // 현재까지 이동 비용이 가장 낮은 도시
+            int now = pq.poll().station;
+
+            // 8.(끝) 만약 현재 도시가 도착 도시라면 탐색 종료
+            if (now == end)
+                break;
+
+            // 2. 최저 비용이 정해진 도시인지 확인
+            if (visited[now])
+                // 2-1. 정해진 도시라면 건너뛰기
+                continue;
+            // 2-2. 정해지지 않은 도시라면 최저 가격 동결을 위한 방문 기록
+            visited[now] = true;
+
+            for (int i = 1; i <= n; i++) {
+                // 3. 방문한 도시부터 다음 도시로 이동이 가능한지 확인
+                if (cities[now][i] == Integer.MAX_VALUE)
+                    // 3-1. 불가능 하다면 건너뛰기
+                    continue;
+
+                // 4. 최저 비용이 정해진 도시인지 확인
+                if (visited[i])
+                    // 4-1. 정해진 도시라면 건너뛰기
+                    continue;
+
+                // 현 도시에서 이동이 가능한 다음 도시까지 비용
+                int newCost = costs[now] + cities[now][i];
+                // 5. 새로 계산한 비용이 기존 이동 비용보다 비싼지 확인
+                if (costs[i] <= newCost)
+                    // 5-1. 비싸다면 건너뛰기
+                    continue;
+
+                // 6. 현재까지의 가격을 기록
+                costs[i] = newCost;
+                // 7. 이동 비용을 기준으로 다음 방문 도시 후보로 등록
+                pq.add(new Bus(i, costs[i]));
+            }
+        }
+
+        return costs[end];
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
`다익스트라`로 푸는 것은 인지하였고 그렇게 풀려고 노력했습니다.

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/1f53baa1-507b-4eec-ba23-b941ce766fe0)
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/4911ae2d-0b63-455c-b800-cbd70b6d3cb0)


## 📝 Review Note
 하지만 다익스트라가 뭔지 제대로 모른다는 사실을 미쳐 몰랐습니다.
 우습게 보고 10분 만에 풀려고 했던 제가 부끄럽네요

 처음에 짠 코드는
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/bdfaeb78-da45-42d1-a0f0-e09af97ef56d)
그래도 다익스트라 향은 났던 모양입니다.

 하지만 `이동 비용이 큰 계산 과정을 가진 선행 탐색 객체를 제거할 방법`을 생각하기가 쉽지 않았습니다.

 그러다 `priority queue`의 존재를 문득 떠올리고 한참을 적용하려 노력했습니다.
 그렇게 1시간이 지나고 겨우 맞췄습니다.

 이 문제의 경우 `q에 add할 때가 아닌 poll할 때 방문을 체크`한다는 부분이 까다롭다고 생각이 듭니다.

 기존의 방문체크는 넣는 순간 갱신이 일어나면 안되기에 add함과 동시에 방문체크를 했지만, `다익스트라의 경우 방문한 노드라도 비용이 적다면 갱신을 해줘야 하기떄문`에 순서 차이가 필요했습니다.

 그리고 여아정씨와 `인접행렬, 인접그래프`를 가지고 한참 `실험`하느라 시도 횟수가 많았습니다.
 `실험 결과`, 이번 문제의 경우 `시작점과 도착점이 중복되는 버스가 존재`하기에, `인접행렬에 최소 값을 넣고 이를 활용`하는 방법이 가장 좋은 시간을 보였습니다.

 또 마지막에 탈출조건을 하나 더 찾아서 시간이 좀 더 줄어서 보람차네요^^

 오랜만에 priority queue도 써보고 dijkstra도 써봐서 유익한 시간이었습니다가구주택~

+그.. 메인에서 브랜치를 파봤지만 더 많은 커밋 친구들이 생겼네요! 하핫^^
  성송합니다..