### PR TITLE
[BOJ] 1197. 최소 스패닝 트리🎄

### DIFF
--- a/여아정/boj_1197.java
+++ b/여아정/boj_1197.java
@@ -1,0 +1,72 @@
+package test_0913;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class boj_1197 {
+    public static class Node implements Comparable<Node> {
+        int idx;
+        int cost;
+
+        public Node(int idx, int cost) {
+            this.idx = idx;
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return cost - o.cost;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int v = Integer.parseInt(st.nextToken());//정점 수
+        int e = Integer.parseInt(st.nextToken());//간선 수
+
+        List<Node>[] goList = new ArrayList[v + 1];//정점마다의 인접 리스트
+        for (int i = 0; i <= v; i++) {
+            goList[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < e; i++) {
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+            //양방향이무로 모두 값 넣어줌
+            goList[start].add(new Node(end, cost));
+            goList[end].add(new Node(start, cost));
+        }
+
+        PriorityQueue<Node> pq = new PriorityQueue<>();//우선순위큐 사용(우선순위 기준은 Node의 cost 오름차순)
+        boolean[] chk = new boolean[v + 1];//체크
+        int All = 0;
+        pq.add(new Node(1, 0));//처음 시작인 1번째 정점을 임의로 넣어준다
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+            int nowIdx = cur.idx;
+
+            if (chk[nowIdx]) continue;//이미 방문한 정점이면 넘어감
+            chk[nowIdx] = true;//방문처리
+            All += cur.cost;//최종비용에 현재 정점으로 오는 비용 더해준다
+
+            for (Node next : goList[nowIdx]) {//현재 정점에서 갈 수 있는 아직 가지 않은 정점은 모두 pq에 넣는다
+                if (chk[next.idx]) continue;
+                pq.add(next);
+            }
+        }
+
+        System.out.println(All);//출력
+
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 1197 최소 스패닝 트리 문제 풀었습니다.
프림과 크루스칼 모두 가능하겠다고 생각했습니다.
저는 프림을 이용해서 풀었습니다.
## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/108220312/06c74ee3-89ca-4bb4-9369-e75b77ad34ea)


## 📝 Review Note
이 문제는 기본적인 크루스칼, 프림 문제로 저번 달에 A형 준비할 때 연습할 때 풀어본 문제였습니다.
다시 프림 알고리즘을 생각하면서 풀기 시작했는데, 오랜만에 다시 푸니 어제 풀었던 다익스트라랑 조금 헷갈릴뻔 했습니다.
그리고 문제를 제대로 읽지못해서 양방향인데 단방향으로만 값을 넣어주어 계속 초반에 틀렸습니다 ..하하핫
문제 꼼꼼히 읽을게유..

프림 문제는 `PriorityQueue`를 이용해서 풀었습니다.
초기 정점을 시작으로 그 정점마다의 인접 리스트를 두어 갈 수 있는 모든 곳을 `PriorityQueue`에 넣고 `pq`에서 가장 비용이 적은 곳부터 poll하여 모든 정점을 연결시킵니다.
 ->이 과정으로 모든 정점이 연결되면, 최소스패닝 트리가 됩니다람쥥

그래프 문제 기본 잘 익혀둬야 할것같습니다. 다시 공부할 수 있어서 좋았습니다람쥥