### PR TITLE
[BOJ] 16916. 부분 문자열

### DIFF
--- a/soomin/BOJ_16916.java
+++ b/soomin/BOJ_16916.java
@@ -4,51 +4,51 @@ import java.io.InputStreamReader;
 
 public class BOJ_16916 {
 
-    static String s,p;
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = br.readLine();
+        String p = br.readLine();
 
-        s = br.readLine();
-        p = br.readLine();
+        System.out.println(kmp(s, p));
+    }
 
-        if(s.length() < p.length()) {
-            System.out.println(0);
-        }
-        else {
-            
-            //  패턴 구하기 ( 접두사와 접미사가 일치하는 패턴)
-            int[] pi = new int[p.length()];
-            failure(pi);
+    private static int kmp(String s, String p) {
 
-            int pointS = 0; // s문자열 인덱스
-            int pointP  = 0; // p문자열 인덱스
-            int result  = 0; // 결과
+        if(s.length() < p.length()) // 거 이러면 볼 필요도 없이 부분 문자열이라고 볼 수 없지용가리
+            return 0;
 
-            while (true) {
-                if(pointS == s.length()) break; // 문자열을 모두 탐색했다면 종료
+        //  패턴 구하기 ( 접두사와 접미사가 일치하는 패턴)
+        int[] pi = new int[p.length()];
+        failure(pi, p);
 
-                if(s.charAt(pointS) == p.charAt(pointP)) { // 일치하면 다음 인덱스로
-                    pointP++;
-                    pointS++;
-                    if(pointP == p.length()) { // p문자열 인덱스가 p 길이와 같아졌다는 것은 p가 s의 부분 문자열이라는 뜻이므로 종료
-                        result = 1;
-                        break;
-                    }
-                }
-                else { // 일치하지 않는다면 패턴만큼 건너 뛰기! KMP!
-                    //pointP = pointS - pi[pointP-1];// 구했던 pi 배열로 일치하지 않는 부분을 건너뛴다. / 좀 이상하게 생각한거 남겨둘라고 안지웠습니다.
-                    if(pointP > 0) // 현재는 일치하지 않지만 이전엔 일치한게 있었다면?
-                        pointP = pi[pointP - 1]; // 일치하지 않는다면 접두사와 접미사가 아닌 부분을 뛰어 넘으면 된다.
-                    else
-                        pointS++;
+        int pointS = 0; // s문자열 인덱스
+        int pointP  = 0; // p문자열 인덱스
+        int result  = 0; // 결과
+
+        while (true) {
+            if(pointS == s.length()) break; // 문자열을 모두 탐색했다면 종료
+
+            if(s.charAt(pointS) == p.charAt(pointP)) { // 일치하면 다음 인덱스로
+                pointP++;
+                pointS++;
+                if(pointP == p.length()) { // p문자열 인덱스가 p 길이와 같아졌다는 것은 p가 s의 부분 문자열이라는 뜻이므로 종료
+                    result = 1;
+                    break;
                 }
             }
-            System.out.println(result);
+            else { // 일치하지 않는다면 패턴만큼 건너 뛰기! KMP!
+                //pointP = pointS - pi[pointP-1];// 구했던 pi 배열로 일치하지 않는 부분을 건너뛴다. / 좀 이상하게 생각한거 남겨둘라고 안지웠습니다.
+                if(pointP > 0) // 현재는 일치하지 않지만 이전엔 일치한게 있었다면?
+                    pointP = pi[pointP - 1]; // 일치하지 않는다면 접두사와 접미사가 아닌 부분을 뛰어 넘으면 된다.
+                else
+                    pointS++;
+            }
         }
+        return result;
     }
 
     // 부분 문자열 P의 접두사 접미사 패턴 구하기
-    private static void failure(int[] pi) {
+    private static void failure(int[] pi, String p) {
         int i = 1; // 패턴을 탐색하는 인덱스
         int j = 0; // 일치하는 부분의 길이 및 인덱스
         pi[0] = 0; // 첫번째 원소의 pi 값은 항상 0

--- a/soomin/BOJ_16916.java
+++ b/soomin/BOJ_16916.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_16916 {
+
+    static String s,p;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        s = br.readLine();
+        p = br.readLine();
+
+        if(s.length() < p.length()) {
+            System.out.println(0);
+        }
+        else {
+            
+            //  패턴 구하기 ( 접두사와 접미사가 일치하는 패턴)
+            int[] pi = new int[p.length()];
+            failure(pi);
+
+            int pointS = 0; // s문자열 인덱스
+            int pointP  = 0; // p문자열 인덱스
+            int result  = 0; // 결과
+
+            while (true) {
+                if(pointS == s.length()) break; // 문자열을 모두 탐색했다면 종료
+
+                if(s.charAt(pointS) == p.charAt(pointP)) { // 일치하면 다음 인덱스로
+                    pointP++;
+                    pointS++;
+                    if(pointP == p.length()) { // p문자열 인덱스가 p 길이와 같아졌다는 것은 p가 s의 부분 문자열이라는 뜻이므로 종료
+                        result = 1;
+                        break;
+                    }
+                }
+                else { // 일치하지 않는다면 패턴만큼 건너 뛰기! KMP!
+                    //pointP = pointS - pi[pointP-1];// 구했던 pi 배열로 일치하지 않는 부분을 건너뛴다. / 좀 이상하게 생각한거 남겨둘라고 안지웠습니다.
+                    if(pointP > 0) // 현재는 일치하지 않지만 이전엔 일치한게 있었다면?
+                        pointP = pi[pointP - 1]; // 일치하지 않는다면 접두사와 접미사가 아닌 부분을 뛰어 넘으면 된다.
+                    else
+                        pointS++;
+                }
+            }
+            System.out.println(result);
+        }
+    }
+
+    // 부분 문자열 P의 접두사 접미사 패턴 구하기
+    private static void failure(int[] pi) {
+        int i = 1; // 패턴을 탐색하는 인덱스
+        int j = 0; // 일치하는 부분의 길이 및 인덱스
+        pi[0] = 0; // 첫번째 원소의 pi 값은 항상 0
+
+        while(true){
+
+            if(i == p.length()) break; // 패턴을 모두 탐색했을 경우
+
+            if(p.charAt(j) == p.charAt(i)) { // 일치한다면 일치하는 길이를 저장 ( j + 1 )
+                pi[i++] = j+1;
+                j++;
+            } else if (j > 0) { // 현재 문자가 일치하진 않지만 이전 위치에선 일치했을 경우
+                j = pi[j-1]; // j를 이전 위치에서 일치하는 부분의 길이로 이동하여 다시 비교한다.
+                //failure(pi, j-1, i);
+            } else { // 현재 문자가 일치하지 않고, 이전 위치에서도 일치하지 않을 경우
+                pi[i] = 0; // 일치하는 부분의 길이를 0으로 설정
+                i++; // 다음 인덱스로 이동해 탐색한다.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
머리아파요. KMP를 예에에에에전에 접해봤던 기억이 나면서 이 문제도 유사한 유형이라 KMP 알고리즘으로 풀었습니다.

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/48270067/bc3a633e-580e-471c-9d52-1e01c0b84088)


## 📝 Review Note
진짜 이해하는데 오래걸렸던 알고리즘 입니다. 말로 설명하려고 하니까 막막한 디유

일단 s문자열보다 p문자열이 더 길면 무조건 부분 문자열이 아니므로 조건문으로 처리해주었습니다.

다음으로는 p문자열의 패턴을 구했습니다.  failure 함수를 만들어서 주어진 패턴의 각 위치에서 일치하는 접두사와 접미사 길이를 나타내는 배열 pi를 계산합니다.

1. i는 패턴을 탐색하는 인덱스이고, j는 현재까지 일치한 부분의 길이를 나타낸다.
2. 만약 현재 문자가 일치한다면, 현재 위치의 pi 값을 일치하는 길이로 설정하고 i와 j를 증가시킨다.
3. 현재 문자가 일치하지 않지만 이전 위치에서 일치하는 부분이 있을 경우 j을 이전 위치에서 일치하는 부분의 길이( pi[j-1] )로 이동해 다시 비교한다.
4. 현재 문자도 일치하지 않고 이전에도 일치하지 않았을 경우 현재 위치의 pi의 값을 0으로 설정하고 다음 위치로 이동한다.

위 로직으로 pi 배열을 만들고 s와 p를 비교합니다. 
위 로직과 거의 동일하게 진행합니다. 이걸 깨닫지 못해서 엄청 오래 걸렸네요 
그림으로 그려봤습니다.

![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/48270067/4467265a-7c55-4c21-b507-02caa1b69292)

수고하셨습니당