### PR TITLE
[BOJ] 16916. 부분 문자열🔠

### DIFF
--- a/여아정/boj_16916.java
+++ b/여아정/boj_16916.java
@@ -1,0 +1,49 @@
+package test_0913;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj_16916 {
+    static int[] pi;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String S = br.readLine();//전체 문자열
+        String P = br.readLine();//부분 문자열
+
+        pi = new int[P.length()];//부분문자열 접두사와 접미사 같은 count 세는 배열
+
+        //pi배열값 먼저 만들기
+        //패턴값을 탐색해서 해당 인덱스까지 접두사와 접미사가 같은 문자 개수 카운트를 모두 저장한다
+        int j = 0;
+        for (int i = 1; i < P.length(); i++) {
+            while (j > 0 && P.charAt(j) != P.charAt(i)) {
+                j = pi[j - 1];
+            }
+            if (P.charAt(i) == P.charAt(j)) {
+                pi[i] = ++j;
+            }
+        }
+        //전체 문자열에서 패턴 문자열 탐색시작
+        System.out.println(doKMP(S,P));
+    }
+
+    private static int doKMP(String S, String P) {
+        int idx = 0;//패턴 문자열의 인덱스
+
+        for (int i = 0; i < S.length(); i++) {//전체 문자열을 돌면서 볼거임
+            while (idx > 0 && S.charAt(i) != P.charAt(idx)) {//패턴문자열이 하나 이상 맞으면서 더이상 맞지 않는 경우가 온다면
+                idx = pi[idx - 1];//idx는  최대 0으로 까지 다시 밀려남
+            }
+
+            if (S.charAt(i) == P.charAt(idx)) {//문자가 같은경우
+                if (idx == P.length() - 1) {//패턴문자 마지막 글자 까지 같은경우
+                    return 1;//이 부분문자열이 존재하니까 더이상 탐색 안해도 됨
+                } else {
+                    idx++;//다음 문자 볼 것
+                }
+            }
+        }
+        return 0;//다 찾아봤지만 부분 문자열은 존재하지 않어유
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
백준 16916 부분 문자열 문제 풀었습니다.
브론즈 문제라서 그냥 완전탐색으로 문자열 탐색을 해도 통과가 가능하겠지만, KMP 연습을 위해서 kmp로 풀었습니다.
## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/108220312/15a86287-f55c-4126-89ce-fe0920d916fa)


## 📝 Review Note
kmp를 대충 이름만 들어보고 자세한 로직에 대해 잘 알지 못했습니다. 그래서 이번에 알고리즘 다시 스터디 시작하면서 로직을 다시 잡으면 좋겠다고 생각했습니다.
kmp 처음 로직 볼 때 어려웠는데 문제를 풀어보니 이 패턴으로 문자열 탐색은 다 사용할 수 있을 것 같습니다.

먼저 부분 문자열의 접두사와 접미사 같은 것 카운트를 한다.
그리고 전체 문자열에서 부분 문자열을 비교하고 같은 게 반복되다가 다른 문자열이 나오면 방금 이전까지 같았던 문자열에서 접두사와 접미사가 같은 부분 카운트 수만큼 앞으로 돌아간다(내가 봐도 뭔 소리인지 이해 못할듯)

근데 여기서 혹시 접두사와 접미사가 절대 같을리 없는 부분문자열이면 완탐이나 다름 없는가? 라고 묻는다면!!!
정답은 아니다.  완탐은 틀린 값이 나오면 다시 처음 부터 탐색을 하는데, kmp를 이용하면 접두사와 접미사가 달라도 일정 값이상 탐색 하다가 다른 값이 나오면 다음 값부터 탐색하므로 어쨌든,!! 무조건 완탐보단 빠르당 하핫

대부분 kmp문제는 플레티넘 등급 이상이던데 다음에 그문제도 풀어봐야겠다.