### PR TITLE
[BOJ] 1931. 회의실 배정 🕛

### DIFF
--- a/성영준/boj_1931_회의실_배정.java
+++ b/성영준/boj_1931_회의실_배정.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class boj_1931_회의실_배정 {
+
+    static class Meeting implements Comparable<Meeting> {
+        int start;
+        int end;
+
+        public Meeting(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        /**
+         * 회의가 끝나는 시간, 시작하는 시간을 기준으로 빠를 수록 우선순위로 뒀음
+         * @param o the object to be compared.
+         * @return 우선순위
+         */
+        @Override
+        public int compareTo(Meeting o) {
+            if(this.end == o.end)
+                return this.start - o.start;
+            return this.end - o.end;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        // 회의 수
+        int n = Integer.parseInt(br.readLine());
+
+        // 우선순위를 기준으로 정렬할 자료구조
+        Queue<Meeting> pq = new PriorityQueue<>();
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            pq.add(new Meeting(start, end));
+        }
+
+        // 사용한 회의 개수
+        int count = 0;
+        // 앞서 진행한 회의의 끝나는 시간
+        int previousEnd = 0;
+
+        while (!pq.isEmpty()) {
+            // 다음 회의 후보
+            Meeting now = pq.poll();
+
+            // 후보 회의의 시작 시간이 현재 회의가 끝나기 전이라면
+            if (previousEnd > now.start)
+                // 넘깁니다
+                continue;
+
+            // 회의를 진행합니다
+            // 회의 개수 + 1
+            count++;
+            // 끝나는 시간 갱신
+            previousEnd = now.end;
+        }
+
+        // 정답 출력
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
## 👩‍💻 Contents
`그리디`라고 생각하고 풀었습니다.

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/2f5b5f44-85c5-485a-821a-c435b0087f84)
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/df064287-c80e-4826-b352-4f6cb03cce9a)


## 📝 Review Note
 ssafy `1학기에 풀었던 문제`로 기억합니다.
 대충 풀이도 기억하고 있어서 `복귀 문제로 적합`하다 생각하여 채택하였습니다.

 `종료 시간을 기준으로 빨리 끝나는 순`으로 카운팅하면 된다는 것을 기억하고 있었습니다.
 그래서 시작 시간도 기준에 둘까 고민할 때, 시작 시간은 종료 시간이 같다면  뭐가 채택되든 같을거라 생각하여, 혹시나 정렬에 시간이 좀 더 걸릴까 기준에 두지 않고 제출하여 앞선 3번을 틀렸습니다.
 문제에서 시작시간과 종료시간이 같은 회의가 있다는 것을 보고 적용하였고 그제서야 성공하였습니다.
 역시 `일반적으로 생각하고 접근해서 풀면 저런 말도 안되는 조건에 틀릴 수 있다는 점` 새삼 깨닫는 계기가 되었습니다.

 그리고 오랜만에 푸니까 좀 어색했습니다.
 이미지에도 보이지만 `20분 정도` 걸렸습니다.
 입력받고, throws걸고, implements걸고 하는 건 지난번 소프티어 때 경험이 있어서 다시 복기하기 까지 얼마 안 걸렸지만,
 compareTo의 기준과 StringTokenizer 사용이 어색했고, ArrayDeque를 어디에 쓸 수 있는지 고민 좀 했습니다.

 풀고 나서 20분정도 최적화를 할 곳을 찾았지만 잘 안 보이네요 유유
 다시 열심히 알고리즘 풀어야징징이~