### PR TITLE
[BOJ] 11003. 최솟값찾기 📉

### DIFF
--- a/성영준/boj_11003_최솟값찾기.java
+++ b/성영준/boj_11003_최솟값찾기.java
@@ -1,0 +1,43 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class boj_11003_최솟값찾기 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int l = Integer.parseInt(st.nextToken());
+
+        Deque<int[]> dq = new ArrayDeque<>();
+
+        st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < n; i++) {
+            int now = Integer.parseInt(st.nextToken());
+
+            while (true) {
+                if (dq.isEmpty())
+                    break;
+
+                if (dq.getLast()[0] < now)
+                    break;
+
+                dq.removeLast();
+            }
+
+            dq.add(new int[]{now, i});
+
+            if (dq.peek()[1] == i - l)
+                dq.removeFirst();
+
+            sb.append(dq.peek()[0]).append(" ");
+        }
+
+
+        System.out.println(sb);
+    }
+}

--- a/성영준/boj_1931_회의실_배정.java
+++ b/성영준/boj_1931_회의실_배정.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class boj_1931_회의실_배정 {
+
+    static class Meeting implements Comparable<Meeting> {
+        int start;
+        int end;
+
+        public Meeting(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        /**
+         * 회의가 끝나는 시간, 시작하는 시간을 기준으로 빠를 수록 우선순위로 뒀음
+         * @param o the object to be compared.
+         * @return 우선순위
+         */
+        @Override
+        public int compareTo(Meeting o) {
+            if(this.end == o.end)
+                return this.start - o.start;
+            return this.end - o.end;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        // 회의 수
+        int n = Integer.parseInt(br.readLine());
+
+        // 우선순위를 기준으로 정렬할 자료구조
+        Queue<Meeting> pq = new PriorityQueue<>();
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            pq.add(new Meeting(start, end));
+        }
+
+        // 사용한 회의 개수
+        int count = 0;
+        // 앞서 진행한 회의의 끝나는 시간
+        int previousEnd = 0;
+
+        while (!pq.isEmpty()) {
+            // 다음 회의 후보
+            Meeting now = pq.poll();
+
+            // 후보 회의의 시작 시간이 현재 회의가 끝나기 전이라면
+            if (previousEnd > now.start)
+                // 넘깁니다
+                continue;
+
+            // 회의를 진행합니다
+            // 회의 개수 + 1
+            count++;
+            // 끝나는 시간 갱신
+            previousEnd = now.end;
+        }
+
+        // 정답 출력
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19w1AGL2Bakqz0qpDxD0tXlRsIY4C2h8%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=5JN6j6z)
## 👩‍💻 Contents
처음엔 슬라이딩 윈도우 인가? 했습니다
그 다음엔 아 우선순위 큐 이구나 하고 메모리 터졌습니다
마지막으로 덱으로 해볼까? 하고 맞췄습니다

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/2e6f1158-9c92-407c-a9b5-8014d0ccf8ad)


## 📝 Review Note
임수빈대떡 덕에 오랜만에 플레 문제 풀었습니다

문제 보자마자 길이도 엄청 짧고
임수빈이 풀었길래 아 이건 꿀이겠거니 하고 들어갔다가 큰 코 다쳤습니다 ㅠㅠ

보자마자 당연히 사람이라면 떠오르는 슬라이딩 윈도우, 그리고 며칠 전 소프티어에서 나온 투포인터로 바로 접근했습니다.
그런데 임수빈씨가 '그렇게 하면 시간초과나' 하면서 손가락으로 절래절래 지휘를 하길래 바로 길 틀었습니다.

두 번째로, 아 우선순위큐로 하면 되겠거니 하고 풀었습니다.
이 방식은
1. 실제 순서대로 값이 들어갈 deque(=dq)
2. 가장 낮은 값을 측정할 Priority queue(=pq)
3. Priority Q 에서 가장 낮은 값을 못 빼는 상황일 때 대기할 수를 저장할 Waiting Priority queue(wating)
를 두고 dq에서 빠진 값이
pq의 가장 앞의 값과 같은, 현재 가장 낮은 값이면 waiting의 모든 값과 일치하는 값이 나올 때 까지 빼고,
pq의 가장 앞의 값과 다르다면 waiting에 뺄 값을 대기하는 식으로 풀었습니다.
그렇게 메모리 초과를 맞이했습니다.

마지막으로, 이제보니까 덱으로만 해도 되겠구나 했습니다.
지금 내가 넣는 값이, 현재 덱의 뒤에서부터 나보다 높은 애들은 다 빼는 식으로 하고 가장 앞의 값을 출력하면 답이겠구나 했습니다.
바로 정답 나왔고 신나는 마음으로 이건 속도 진짜 빠르다 확신하고 임수빈과 속도 비교하려고 순위표 봤습니다.
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/b128d3da-dd69-42a9-99da-93b64b0d2087)
그런데 왠 이준서가 가장 빠른 코드로 있어서 이래 저래 어둥버둥대다가
더 나은 방법 못 찾고 포기했습니다.

씁쓸하네요