### PR TITLE
[BOJ] 1167. 트리의지름 🌳📏

### DIFF
--- a/성영준/boj_1167_트리의지름.java
+++ b/성영준/boj_1167_트리의지름.java
@@ -1,0 +1,73 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+class Edge {
+    int node;
+    int value;
+
+    public Edge(int node, int value) {
+        this.node = node;
+        this.value = value;
+    }
+}
+
+
+public class boj_1167_트리의지름 {
+    static Edge max = new Edge(0, 0);
+    static boolean[] checked;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int v = Integer.parseInt(br.readLine());
+
+        List<Edge>[] distances = new ArrayList[v + 1];
+        for (int i = 1; i <= v; i++)
+            distances[i] = new ArrayList<>();
+
+        for (int i = 0; i < v; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int now = Integer.parseInt(st.nextToken());
+
+            while (true) {
+                int next = Integer.parseInt(st.nextToken());
+
+                if (next == -1)
+                    break;
+
+                int distance = Integer.parseInt(st.nextToken());
+
+                distances[now].add(new Edge(next, distance));
+            }
+        }
+
+        checked = new boolean[v + 1];
+        dfs(1, 0, v, distances);
+
+        checked = new boolean[v + 1];
+        dfs(max.node, 0, v, distances);
+
+        System.out.println(max.value);
+    }
+
+    private static void dfs(int now, int sum, int v, List<Edge>[] distances) {
+        checked[now] = true;
+
+        for (Edge next : distances[now]) {
+            if (next.value == 0)
+                continue;
+
+            if (checked[next.node])
+                continue;
+
+            dfs(next.node, sum + next.value, v, distances);
+        }
+
+        if (sum > max.value)
+            max = new Edge(now, sum);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1EjVLUsXlGYd0fQrtrMF5LtZhQtnvrA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=tM2bKJ5)
This reverts commit 9769c6b32a6a08b50be8e33f84d88101feaf49e9.

## 👩‍💻 Contents
dfs에 인접배열하면 쉽겠지만 효율 떨어지겠는데?
하니까 메모리초과 뜨고
인접배열이 아니고 인접리스트로 하면 풀리긴 하겠지만 효율 떨어지겠는데?
하니까 진짜 시간초과뜨고
dfs 2번으로 푸는 방법으로 풀었습니다

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/4c9c9d5f-3b6c-4d46-bcc2-afd737197cea)

## 📝 Review Note
근데 저 방식을 차센세한테 들었습니다

듣고 나니 엄청 쉽게 풀리더군요

예전에 https://github.com/JaMongDan/rehabilitation_algorithm/pull/61
제가 이 문제로 비슷한 접근을 2번째에 했었는데 감회가 새롭네요
저 문제도 내친김에 리뷰 해주새우 ㅠㅠ
아무도 리뷰 안해줘서 그냥 머지했던 문제에요