### PR TITLE
[BOJ] 1238. 파티 🎉

### DIFF
--- a/성영준/boj_1238_파티.java
+++ b/성영준/boj_1238_파티.java
@@ -1,0 +1,88 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class boj_1238_파티 {
+    public static class Info implements Comparable<Info> {
+        int destination;
+        int distance;
+
+        public Info(int destination, int distance) {
+            this.destination = destination;
+            this.distance = distance;
+        }
+
+        @Override
+        public int compareTo(Info o) {
+            return distance - o.distance;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int x = Integer.parseInt(st.nextToken());
+
+        List<Info>[] goInfos = new List[n + 1];
+        for (int i = 1; i <= n; i++)
+            goInfos[i] = new ArrayList<>();
+
+        List<Info>[] backInfos = new List[n + 1];
+        for (int i = 1; i <= n; i++)
+            backInfos[i] = new ArrayList<>();
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            int d = Integer.parseInt(st.nextToken());
+
+            goInfos[s].add(new Info(e, d));
+            backInfos[e].add(new Info(s, d));
+        }
+
+        int[] goDist = new int[n + 1];
+        for (int i = 1; i <= n; i++)
+            Arrays.fill(goDist, Integer.MAX_VALUE);
+        dijkstra(x, goDist, n, goInfos);
+
+        int[] backDist = new int[n + 1];
+        for (int i = 1; i <= n; i++)
+            Arrays.fill(backDist, Integer.MAX_VALUE);
+        dijkstra(x, backDist, n, backInfos);
+
+        int answer = 0;
+        for (int i = 1; i <= n; i++)
+            answer = Math.max(answer, goDist[i] + backDist[i]);
+
+        System.out.println(answer);
+    }
+
+    public static void dijkstra(int destination, int[] dist, int n, List<Info>[] infos) {
+        PriorityQueue<Info> pq = new PriorityQueue<>();
+
+        dist[destination] = 0;
+        pq.add(new Info(destination, 0));
+
+        while (n > 0) {
+            Info now = pq.poll();
+            int index = now.destination;
+
+            if (dist[index] < now.distance)
+                continue;
+
+            for (Info next : infos[index])
+                if (dist[next.destination] > dist[index] + next.distance) {
+                    dist[next.destination] = dist[index] + next.distance;
+                    pq.add(new Info(next.destination, dist[next.destination]));
+                }
+
+            n--;
+        }
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1GmNUr9kGHmhxLV70mS80QWs6CC7cDYI%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=h6pXG4M)
## 👩‍💻 Contents
처음엔 dfs라고 인지하고 풀었습니다
하지만 시간초과가 나온 후 dijkstra임을 눈치챘습니다

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/c53cbf0f-d026-404a-b176-0db274a48c72)

## 📝 Review Note
오랜만에 광기에 절여져서 푸니까 재밌네요
피곤해서 첫페이지에 올라가는 도전은 못하겠습니다

1. dfs네 (시간초과)
안일했습니다
근데 사실 대충 인지는 했습니다 시간초과겠거니
그냥 실패를 보고 나면 좀 더 부스팅 되기도 하고 코드 작성 연습도 할 겸 진행했습니다

2. dijkstra네 (1012ms)
맞았습니다
2번에서 모든 지점으로 가고,
모든 지점에서 2번으로 오고
하는 메서드를 하나 작성해서 공동 사용하도록 풀었습니다

3. 돌아올 땐 2에서 멈추게 (664, 620ms)
dijkstra 탐색을 파티장소에 도착하면 멈추게 하는 로직을 넣고 싶었습니다

4. dijkstra에 pq 도입해도 되네 (원래 하는거네 유유) (492ms)
바보같이 하고 있음을 인지하고 pq를 도입했습니다

5. dijkstra를 돌아오는 길을 반대로 생각하면 되네 (160ms)
이게 젤 획기적이었습니다
파티장소에서 집으로 가는 작업은 원래 dijkstra로 파티장소에서 모든 출발지로의 단거리 검색이 한번에 가능했습니다
원래 dijkstra가 한 점에서 출발하여 모든 점으로 가는 가장 짧은 거리를 구하는 공식이니까요
하지만 반대로 하는 경우는 출발지에서 파티장소, 그러니까 어떤 점에서 한 점으로 반대로 탐색을 어떤 점의 수만큼 진행해야하기에 매우 비효율 적이었습니다
그래서 돌아오는 길의 거리를 반대로 두어 파티장소에서 출발지로, 그러니까 한 점에서 어떤 점으로 가게끔 한 후 dijkstra를 진행하면 구한 값이 사실은 반대로 가는 거리의 값이 나오는 것이므로 해당 풀이를 적용했습니다

첫페이지까지 20ms남았는데 피곤해서 더 못하겠네요
만족하고 자겠습니다람쥐렁이
숙5ring