### PR TITLE
[BOJ] 25370. 카드 숫자 곱의 경우의 수 🃏🔢✖️

### DIFF
--- a/성영준/boj_25370_카드숫자곱의경우의수.java
+++ b/성영준/boj_25370_카드숫자곱의경우의수.java
@@ -1,0 +1,28 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+
+public class boj_25370_카드숫자곱의경우의수 {
+    static HashSet<Integer> checked = new HashSet<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        dfs(1, 1, 0, n);
+
+        System.out.println(checked.size());
+    }
+
+    public static void dfs(int index, int now, int depth, int n) {
+        if (depth == n) {
+            checked.add(now);
+            return;
+        }
+
+        for (int i = index; i <= 9; i++) {
+            dfs(i, now * i, depth + 1, n);
+        }
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18onGDgvFxU3ydvQ3czL7E6n20pZhStTE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Jw9Bn8t)
## 👩‍💻 Contents
수학 문제라 생각하고 접근했습니다

## 📱 Screenshot
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/b6308881-f571-42ca-9a01-02c731a71be0)

## 📝 Review Note
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/c1b51197-9876-4fdd-bb28-246d398a7907)
근데 그냥 완탐이네 ㅠㅠ

첫 풀이에서 맞는 코드 작성해놓고 dfs에 return 안해서 '아 완탐해서 오버났구나' 싶었습니다 ㅠㅠ
그렇게 20분 버리고 발견해서 맞췄습니다
먼저 9의 9승이 Integer 범위 내부인 것을 확인하고 (10의 10승이 10억이니) boolean 배열을 만들고 확인했습니다

그런데 너무 느려서 당황했습니다
![image](https://github.com/JaMongDan/rehabilitation_algorithm/assets/75199294/d66b1be6-4eec-413c-bc6c-3905b30096d9)
296ms는 그냥 젤 꼴지 코드였습니다

그래서 효율적으로 어떻게 해볼까 하다가 set을 생각했습니다
적용하고 확인해보니 확실히 메모리는 줄었는데 시간은 오히려 더 소비되었습니다(328ms)

그래서 마지막으로 숫자의 순서는 바껴도 값은 그대로이니 이전에 뽑은 값보다 낮은 값이 다음 값으로 선정되지 않도록 했습니다(72ms)

너무 쉬운 문제였는데 난이도 가리고 보니까 좀 당황스럽긴 하네요 ㅠㅠ
시간도 20분 설정해놓고 20분 더 걸렸습니다 ㅠㅠ