### PR TITLE
[BOJ]1141. 접두사

### DIFF
--- a/soomin/Main.java
+++ b/soomin/Main.java
@@ -1,10 +1,9 @@
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
-import java.util.PriorityQueue;
-import java.util.Set;
 
 public class Main {
     // 그리디? => 각 문자열을 이중 포문 N2, 문자열 비교시 M => O(N2M)
@@ -12,33 +11,33 @@ public class Main {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
         int N = Integer.parseInt(br.readLine());
-
-        PriorityQueue<String> sortedStrings = new PriorityQueue<>((o1, o2) -> {
-            return o2.length() - o1.length();
-        }); // 내림차순으로 정렬 => 부분집합이 제일 많아야하니까! 길이가 짧은 순으로 먼저 들어가버리면 접두사가 될 확률이 높다!
-        for(int i = 0; i<N; i++){
-            sortedStrings.add(br.readLine());
+        String[] str = new String[N];
+        for (int i = 0; i < N; i++) {
+            str[i] = br.readLine();
         }
 
-        Set<String> strings = new HashSet<>(); // 입력으로 중복값이 주어질 수 있음
-        strings.add(sortedStrings.poll()); // 하나 넣고 시작
-        
-        while(!sortedStrings.isEmpty()) {
+        Arrays.sort(str, Comparator.reverseOrder()); // 내림차순 => 그리디 탐색을 위하여 (긴 값이 먼저 채택되어야 가장 많은 부분집합을 선택할 수 있다. )
+        ArrayList<String> words = new ArrayList<>(); // => 굳이 자료구조를 만들지 않고 count만 셀 수는 없을까?
+        words.add(str[0]);
 
-            String target = sortedStrings.poll();
+
+        for (int i = 1; i < N; i++) {
+
+            String target = str[i];
             boolean isPrefix = false;
 
-            for(String str : strings) {
-                // 최적화: target이 str보다 작거나 같을때만 비교함 (target이 더 크면 접두사가 될 수 없음)
-                if(target.length() > str.length()) continue;
-                if(str.indexOf(target) == 0) {// 0번째 인덱스에 target이 있으면 접두사임
+            for(String word : words) {
+                if(target.length() > word.length()) continue;   // 최적화: target이 str보다 작거나 같을때만 비교함 (target이 더 크면 접두사가 될 수 없음)
+                if(word.indexOf(target) == 0) { // 0번째 인덱스에 target이 있으면 접두사임
                     isPrefix = true;
                     break;
                 }
             }
-            if(!isPrefix) strings.add(target); // 삽입
+
+            if(!isPrefix) words.add(target);
         }
 
-        System.out.println(strings.size());
+        System.out.println(words.size());
+
     }
 }

--- a/soomin/Main.java
+++ b/soomin/Main.java
@@ -1,9 +1,7 @@
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 
 public class Main {
     // 그리디? => 각 문자열을 이중 포문 N2, 문자열 비교시 M => O(N2M)
@@ -16,28 +14,15 @@ public class Main {
             str[i] = br.readLine();
         }
 
-        Arrays.sort(str, Comparator.reverseOrder()); // 내림차순 => 그리디 탐색을 위하여 (긴 값이 먼저 채택되어야 가장 많은 부분집합을 선택할 수 있다. )
-        ArrayList<String> words = new ArrayList<>(); // => 굳이 자료구조를 만들지 않고 count만 셀 수는 없을까?
-        words.add(str[0]);
+        Arrays.sort(str);
 
-
-        for (int i = 1; i < N; i++) {
-
-            String target = str[i];
-            boolean isPrefix = false;
-
-            for(String word : words) {
-                if(target.length() > word.length()) continue;   // 최적화: target이 str보다 작거나 같을때만 비교함 (target이 더 크면 접두사가 될 수 없음)
-                if(word.indexOf(target) == 0) { // 0번째 인덱스에 target이 있으면 접두사임
-                    isPrefix = true;
-                    break;
-                }
-            }
-
-            if(!isPrefix) words.add(target);
+        int count = 1;
+        for (int i = 1; i < N; i++) { // 버블정렬? => 인접한 원소만 비교해도 된다. 왜냐면 알파벳 순으로 정렬했으니까 그게 보장이 된다!
+            if (str[i].equals(str[i-1])) continue;
+            if (str[i].indexOf(str[i - 1]) == 0) continue;
+            count++;
         }
 
-        System.out.println(words.size());
-
+        System.out.println(count);
     }
 }

--- a/soomin/Main.java
+++ b/soomin/Main.java
@@ -1,0 +1,44 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+public class Main {
+    // 그리디? => 각 문자열을 이중 포문 N2, 문자열 비교시 M => O(N2M)
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        PriorityQueue<String> sortedStrings = new PriorityQueue<>((o1, o2) -> {
+            return o2.length() - o1.length();
+        }); // 내림차순으로 정렬 => 부분집합이 제일 많아야하니까! 길이가 짧은 순으로 먼저 들어가버리면 접두사가 될 확률이 높다!
+        for(int i = 0; i<N; i++){
+            sortedStrings.add(br.readLine());
+        }
+
+        Set<String> strings = new HashSet<>(); // 입력으로 중복값이 주어질 수 있음
+        strings.add(sortedStrings.poll()); // 하나 넣고 시작
+        
+        while(!sortedStrings.isEmpty()) {
+
+            String target = sortedStrings.poll();
+            boolean isPrefix = false;
+
+            for(String str : strings) {
+                // 최적화: target이 str보다 작거나 같을때만 비교함 (target이 더 크면 접두사가 될 수 없음)
+                if(target.length() > str.length()) continue;
+                if(str.indexOf(target) == 0) {// 0번째 인덱스에 target이 있으면 접두사임
+                    isPrefix = true;
+                    break;
+                }
+            }
+            if(!isPrefix) strings.add(target); // 삽입
+        }
+
+        System.out.println(strings.size());
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19MsE7muIApnTFJcM1EomBdWNgng%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=1nCWE6a)
## 👩‍💻 Contents
완탐? 그리디로 문제 풀었습니다. 

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/9bc5da83-9e89-4fdc-83f8-c369ac46f05d)

## 📝 Review Note
최대한 최적화를 연습해보려고 했습니다.

처음 로직은 
1. 그리디를 위해서 pq에 입력값을 모두 담았습니다. 길이가 긴 순서로 내림차순을 했구용
2. 반복문으로 pq의 값을 하나씩 빼서 해당 값을 target이라고 했을 때 이 target이 집합에 들어가도 되는지 판단합니다.
3. 판단은 집합에 이미 들어있는 원소들과 비교해서 접두사인지 체크합니다. 
4. 아니라면 target은 집합에 들어갈 수 있습니다.

저는 이 로직에서 PQ, Set을 사용했습니다. 시간이 많이 나와서 줄일 수 있는 방법을 고민했습니다.

두번째 로직은 좀 잘 못 짯습니다. 19번째 줄 주석을 좀 잘못 달았슴다. 
일단 굳이 pq일 필요가 없다고 생각했습니다. 삽입할때마다 정렬을 하기 때문에요
ArrayList를 사용해서 pq와 동일하게 정렬을 해줬습니다. 근데 이렇게 되면 알파벳 순으로 정렬이 되는데 바보같이 길이로 정렬된다고 첫번째코드에 생각이 머물러서 그렇게 생각하고 풀었습니다. 그래서 좀 어 정렬이 의미가 없습니다!

세번째 로직은 이제 제가 ArrayList를 사용한 정렬이 알파벳 순이라는 걸 깨닫고 이를 이용한 방법을 생각해봤습니다. 그리고 집합 원소의 수를 구하는 문제이기 때문에 굳이 집합을 변수에 할당해서 원소를 저장할 필요없이 count 변수를 사용해 끝내고 싶었습니다. 

1. 입력받고 알파벳 순으로 정렬합니다.
2. 버블정렬과 같이 현재 원소(target)가 이전 원소의 접두사인지 확인합니다. 
- 왜냐하면 알파벳순으로 정렬이 되었다는 것은 인접한 문자열만 비교해서 통과하면 보장된다는 것입니다. 
- 왕 h, hello, hjd 이렇게 있다고 치면 h와 hello를 비교하면 count를 세지 않습니다. h와 hello가 안된다면 h와 hjd도 안되는 게 보장이 됩니다. 알파벳 순이니까요!
-  hello와 hjd를 비교하면 count를 세서 1이고 이미 count를 1로 초기화하기 때문에 2가 답입니다. (hello를 포함하기 때문에)


다행히 시간이 대폭 줄어들어서 3등 했슴다. 다른 분들 코드를 봤는데 바로 제 위에 분이 저처럼 버블정렬을 사용했슴다. 먼가 영광이었슴다 
감삼다