### PR TITLE
[BOJ]5547. 일루미네이션

### DIFF
--- a/soomin/BOJ_5547.java
+++ b/soomin/BOJ_5547.java
@@ -1,0 +1,86 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+class House {
+    int y, x;
+
+    House(int y, int x) {
+        this.y = y;
+        this.x = x;
+    }
+}
+
+public class BOJ_5547 {
+
+    static int[][] moveEven = {{0, -1}, {-1, -1}, {-1, 0}, {0, 1}, {1, 0}, {1, -1}}; // 짝수
+    static int[][] moveOdd = {{0, -1}, {-1, 0}, {-1, 1}, {0, 1}, {1, 1}, {1, 0}}; // 홀수
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        // 일단 고민인점 어떻게 외부 벽만 체크하지?
+        // 사실은 육각형임 띠용!
+
+        // 1과 0이 만나는 변을 카운트!
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int W = Integer.parseInt(st.nextToken()); // 가로
+        int H = Integer.parseInt(st.nextToken()); // 세로
+
+        int[][] map = new int[H + 2][W + 2];
+        boolean[][] visited = new boolean[H + 2][W + 2];
+
+        for (int i = 1; i <= H; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= W; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // bfs로 0인 것만 탐색한다 => 주변에 1인 건물이 있다면? 현재 위치에 +1
+        Queue<House> q = new ArrayDeque<>();
+
+        q.add(new House(0, 0));
+        visited[0][0] = true;
+        int totalWalls = 0;
+
+        while (!q.isEmpty()) {
+
+            House now = q.poll(); // 현재 탐색 위치
+            for (int d = 0; d < 6; d++) {
+
+                int ny = 0, nx = 0;
+
+                if (now.y % 2 == 0) { // 짝수라면
+                    ny = now.y + moveEven[d][0];
+                    if (ny < 0 || ny > H + 1) continue; // 테두리
+                    nx = now.x + moveEven[d][1];
+                    if (nx < 0 || nx > W + 1) continue;
+                } else {
+                    ny = now.y + moveOdd[d][0];
+                    if (ny < 0 || ny > H + 1) continue;
+                    nx = now.x + moveOdd[d][1];
+                    if (nx < 0 || nx > W + 1) continue;
+                }
+
+                // 인접한 곳이 집이라면? => 외벽을 세야지!
+                if (map[ny][nx] == 1) {
+                    totalWalls++;
+                    continue;
+                }
+
+                // 방문체크
+                if (visited[ny][nx]) continue;
+
+                visited[ny][nx] = true;
+                q.add(new House(ny, nx)); // 0인곳을 큐에 넣는다!!
+            }
+        }
+
+        System.out.println(totalWalls);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19E05qmsSnWNqLweOgzX7CIKZM5m4KxnxE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=O6Ocf-a)
BFS

## 👩‍💻 Contents
bfs로 풀었슴당나귀

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/5e9f5a01-fcd7-41ce-9f56-b0172f2e4fa1)


## 📝 Review Note
ㅋ....
시간이 엄청 오래걸렸습니당... 이유는 일단 좌표가 문제엔 반대로 써있었고 사각형이 아닌 육각형이라 헷갈렸습니다. 그리고 건물의 외벽만 세야한다는 점에서 생각을 좀 오래했습니다. 
근데 막상 생각하고 나니까 별 다를 건 없었습니다. 꼼꼼하게 고려했으면 2시간은 단축했을 것 같습니다.

건물의 외벽만 세기 위해서 0인 부분을 탐색하면서 1을 만날때마다 현 좌표의 count값을 증가했습니다. (외벽의 수!)

로직만 보면 이지 한테 이게 건물의 내벽을 포함하지 않는 다는 것을 직접 그려보고 깨달았습니다. 내벽을 제외하는 다른 로직을 생각해야하는 줄 알고 머리카락 좀 쥐어뜯었는데 그럴 필요가 없었습니다. 왜냐면 0을 탐색하고 1은 건너뛰기 때문에 탐색에 1로 둘러쌓인 내부의 0이 포함될 일이 없기 때문입니다!

감삼다 
이게 y가 홀수일때, 짝수일때 이동하는 좌표가 좀 다른데 여기에서 하나 틀려서 2시간 더 잡고 있었습니다 유