### PR TITLE
[BOJ] 26090. 완전한 수열

### DIFF
--- a/성영준/boj_26090_완전한수열.java
+++ b/성영준/boj_26090_완전한수열.java
@@ -1,0 +1,74 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 에라토스테네스의 체 와 누적 합을 요구하는 문제
+ */
+public class boj_26090_완전한수열 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        // 누적합을 저장할 배열
+        int[] sequence = new int[n + 1];
+        for (int i = 1; i <= n; i++)
+            sequence[i] = Integer.parseInt(st.nextToken()) + sequence[i - 1];
+
+        // 최종 누적 합과 배열의 길이를 비교하여 큰 값을 한계 값으로 지정
+        // 이 문제의 경우 0도 포함되어 있기 때문에 누적합이 n보다 작을 수 있어서 고려함
+        int limit = Math.max(sequence[n], n) + 1;
+        boolean[] isNotPrime = new boolean[limit];
+        setNotPrimeArray(isNotPrime, limit);
+
+        // 정답으로 출력할 변수
+        int count = 0;
+        // 배열의 길이 또한 소수여야 하기에 n + 1에서 2를 뺸 값 까지 탐색
+        // 변수화 한 이유는 for문의 범위가 계산식으로 되어 있으면 느림
+        // 속도를 줄이기 위한 잡기술 1
+        int last1 = n - 1;
+        for (int i = 0; i < last1; i++) {
+            // j = i + 2; j <= last1으로 하지 않은 이유는
+            // 내부의 첫 번째 조건문이 i - j로 계산식이 세워지면 느려지기에
+            // j = 2 부터 출발하여 첫 번째 조건문에서 바로 값이 쓰이도록 함
+            // 대신 limit의 경우 따로 계산하여 변수화
+            // 속도를 줄이기 위한 잡기술 2
+            int last2 = n - i;
+            for (int j = 2; j <= last2; j++) {
+                // 길이가 소수가 아니라면 skip
+                if (isNotPrime[j])
+                    continue;
+
+                // 합이 소수가 아니라면 skip
+                int sum = sequence[i + j] - sequence[i];
+                if (isNotPrime[sum])
+                    continue;
+
+                count++;
+            }
+        }
+
+        System.out.println(count);
+    }
+
+    /**
+     * 에라토스테네스의 체를 생성하는 함수
+     * @param isNotDecimal 에라토스테네스의 체
+     * @param limit 한계 값
+     */
+    private static void setNotPrimeArray(boolean[] isNotDecimal, int limit) {
+        // 제곱된 값부터 탐색을 시작하기에 한계 값의 제곱근 까지 범위 고려
+        int sqrt = (int) Math.sqrt(limit);
+
+        // 이 문제의 경우 0도 포함되어 있어서 0과 1을 사전에 true로 초기화
+        isNotDecimal[0] = true;
+        isNotDecimal[1] = true;
+        // 소수의 제곱부터 한계 값까지 합성수로 지정
+        for (int i = 2; i <= sqrt; i++)
+            if (!isNotDecimal[i])
+                for (int j = i * i; j < limit; j += i)
+                    isNotDecimal[j] = true;
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1dzdvjs3XowgK0H392nj6eZhGWHmX4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=FmbZ0nJ)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/26090
에라토스테네스의 체 와 누적 합을 요구하는 문제였습니다

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/52c69eef-1ff0-4e56-bfb2-3965bebc52ed)

## 📝 Review Note
처음에 틀린 이유는 문제를 잘못 읽었습니다
문제가 좀 헷갈리게 나왔다고 생각했는데
다시 깨닫고 풀고 나서 읽으니까 제가 그냥 부주의했네요 유유

깨달은 뒤엔 보수공사 좀 한 것 말고 바로 풀었습니다

그런데 1등이 100ms로 저랑 8ms 차이 나길래 어느 부분에서 났을까 고민 좀 했습니다

알아낸 결과, 제가 에라토스테네스의 채를 초기화 하는 과정에서
```
        for (int i = 2; i <= sqrt; i++)
            if (!isNotDecimal[i])
                for (int j = i * i; j < limit; j += i)
                    isNotDecimal[j] = true;
```
에서
```
                for (int j = i * i; j < limit; j += i)
```
이 조건을

```
                for (int j = i * 2; j < limit; j += i)
```
이렇게 사용하고 있었습니다

머리로는 어떤 수는 이미 소수일 경우
다음 배수부터 표시해야 한다
라고 판단하고 저렇게 작성했었는데
생각해보니
어떤 수 n의 이전 수들인 n * 2, n * 3 ... n * (n - 1)의 경우는 이미 이 전 수 단계에서 합성수로 초기화가 된 상태였습니다

또한 에라토스테네스 채 배열의 길이를 고려 좀 했습니다
그 경우는 주석에 있으니 주석으로 보새우

그럼 수고링