### PR TITLE
[BOJ]1967. 트리의 지름

### DIFF
--- a/soomin/BOJ_1967.java
+++ b/soomin/BOJ_1967.java
@@ -49,6 +49,8 @@ public class BOJ_1967 {
         visited[1] = true;
         dfs(1, 0);
 
+        max = 0;
+
         // 찾은 리프노드를 기준으로 경로를 계산
         visited = new boolean[n + 1];
         visited[maxIndex] = true;

--- a/soomin/BOJ_1967.java
+++ b/soomin/BOJ_1967.java
@@ -16,8 +16,8 @@ public class BOJ_1967 {
 
     static int max = 0;
     static List<Node>[] nodes;
-    static Map<Integer, Map<Integer, Integer>> nodeMap;
     static boolean[] visited;
+    static int maxIndex = 1;
 
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -37,32 +37,37 @@ public class BOJ_1967 {
             int w = Integer.parseInt(st.nextToken());
 
             nodes[s].add(new Node(e, w));
-            nodes[e].add(new Node(s, w));
+            nodes[e].add(new Node(s, w)); // 리프노드를 기준으로 탐색을 역으로 해야하기 때문
         }
 
         // dfs로 깊이우선탐색을하면서 가장 긴 구간을...갱신?
         // 부모 어디서 부터 어디까지 더하기를 해야하는 걸까? => 모든 노드에서 깊이우선 탐색 갈기기? 그중 젤 긴거 두개?
         // 어떤 두 노드를 선택해도 둘 사이에 경로가 항상 1개만 존재한다는 말은 무조건 이진트리라는 걸까
-        // 모든 노드는 불필요해보인다 어쨋든 리프노드까지 탐색을 할때니 리프노드들만 돌면 되지 않을까?
-        for (int i = 1; i <= n; i++) {
-            if(nodes[i].size() == 1) {
-                visited = new boolean[n+1];
-                visited[i] = true;
-                dfs(i, 0);
-            }
-        }
+
+        // 루트를 기준으로 가장 비용이 큰 리프노드를 찾!
+        visited = new boolean[n + 1];
+        visited[1] = true;
+        dfs(1, 0);
+
+        // 찾은 리프노드를 기준으로 경로를 계산
+        visited = new boolean[n + 1];
+        visited[maxIndex] = true;
+        dfs(maxIndex, 0);
 
         System.out.println(max);
     }
 
     /**
-     * dfs로 리프노드들을 탐색하면서 가장 최대 비용을 가진 경로를 찾습니다.
+     * dfs로 노드를 탐색하면서 가장 최대 비용을 가진 경로를 찾습니다.
      * @param index 리프노드의 번호
      * @param sum 비용 합산
      */
     private static void dfs(int index, int sum) {
 
-        max = Math.max(sum, max);
+        if(max < sum) {
+            max = sum;
+            maxIndex = index;
+        }
 
         for(Node next : nodes[index]) {
             if(visited[next.end]) continue; // 방문체크!

--- a/soomin/BOJ_1967.java
+++ b/soomin/BOJ_1967.java
@@ -1,0 +1,74 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+class Node {
+    int end, weight;
+
+    public Node(int end, int weight) {
+        this.end = end;
+        this.weight = weight;
+    }
+}
+
+public class BOJ_1967 {
+
+    static int max = 0;
+    static List<Node>[] nodes;
+    static Map<Integer, Map<Integer, Integer>> nodeMap;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        // 어떤 자료구조를 써야할까? 인접행렬일까 인접리스트일까? 맵은 괜찮나? => 인접리스트 아님 맵?
+        // 부모를 알아야할 것 같아여
+        nodes = new ArrayList[n + 1];
+        for (int i = 0; i <= n; i++) {
+            nodes[i] = new ArrayList<>();
+        }
+
+        for (int i = 1; i < n; i++) { // 아으
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            nodes[s].add(new Node(e, w));
+            nodes[e].add(new Node(s, w));
+        }
+
+        // dfs로 깊이우선탐색을하면서 가장 긴 구간을...갱신?
+        // 부모 어디서 부터 어디까지 더하기를 해야하는 걸까? => 모든 노드에서 깊이우선 탐색 갈기기? 그중 젤 긴거 두개?
+        // 어떤 두 노드를 선택해도 둘 사이에 경로가 항상 1개만 존재한다는 말은 무조건 이진트리라는 걸까
+        // 모든 노드는 불필요해보인다 어쨋든 리프노드까지 탐색을 할때니 리프노드들만 돌면 되지 않을까?
+        for (int i = 1; i <= n; i++) {
+            if(nodes[i].size() == 1) {
+                visited = new boolean[n+1];
+                visited[i] = true;
+                dfs(i, 0);
+            }
+        }
+
+        System.out.println(max);
+    }
+
+    /**
+     * dfs로 리프노드들을 탐색하면서 가장 최대 비용을 가진 경로를 찾습니다.
+     * @param index 리프노드의 번호
+     * @param sum 비용 합산
+     */
+    private static void dfs(int index, int sum) {
+
+        max = Math.max(sum, max);
+
+        for(Node next : nodes[index]) {
+            if(visited[next.end]) continue; // 방문체크!
+            visited[next.end] = true;
+            dfs(next.end, sum+next.weight);
+        }
+
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX17nVuRpcnj7lr6cSvPwQVlGep5LiokPTQ%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=G-y2lPM)
## 👩‍💻 Contents
dfs라고 생각했고 맞았습니다. 다만 완탐을 좀 겉들인?

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/5bf938cc-5598-4b7e-9ed1-5719419e502c)
1등이 80ms라 충격먹고 고민해서 줄였습니다.

## 📝 Review Note
일단 처음에는 모든 노드를 기준으로 dfs를 하려고 했었는데 굳이 그럴 필요가 있나 싶었습니다. 어쨌든 모든 경로에 리프 노드는 포함이 될테니까 
리프노드를 구해서 해당 노드들을 기준으로 dfs를 돌았고 시간이 엄청 길게 나왔습니다. 1등과 시간차가 어마어마해서 리프노드를 다 도는 게 아니라 제일 긴 길이를 가질 수 있는 리프노드를 찾을려고 했습니다. 
그래서 제 로직은 dfs를 두번 수행합니다. 

1. 가장 큰 비용을 가지는 리프노드를 찾기 위해서 루트부터 dfs 탐색하며 max값을 갱신하고 갱신 될때마다 노드 번호도 갱신합니다. 그래서 가장 길게 될 수 있는 경로를 탐색함다
2. 그리고 찾은 리프노드를 가지고 다시 한번 dfs를 탐색합니다. 물론 dfs 탐색전에 max, visited 초기화 해야합니다

근데도 180ms 나왔습니다... 80ms은 그 분 코드를 봐야알 것 같아요 여기서 더 어캐 줄이지??


감삼다 피드백 환영합니당