### PR TITLE
[BOJ] 18427. 함께 블록 쌓기 🟥🟧🟨🟩🟦🟪

### DIFF
--- a/성영준/boj_18427_함께블록쌓기.java
+++ b/성영준/boj_18427_함께블록쌓기.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/**
+ * dp 문제
+ */
+public class boj_18427_함께블록쌓기 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int h = Integer.parseInt(st.nextToken());
+
+        // memorize용, 학생 별 블록의 높이 저장
+        int[][] blocks = new int[n + 1][h + 1];
+
+        // 계산용, 학생 별 블록의 높이 저장
+        Queue<Integer>[] students = new ArrayDeque[n + 1];
+        for (int i = 1; i <= n; i++)
+            students[i] = new ArrayDeque<>();
+
+        for (int student = 1; student <= n; student++) {
+            // 이 학생 블록들을 사용하지 않을 수 있음
+            // 그럴 땐 그대로 내려야 함
+            students[student].add(0);
+
+            st = new StringTokenizer(br.readLine());
+            while (st.hasMoreTokens()) {
+                // 현재 블록의 높이가 탑의 높이를 넘지 않는다면 저장 (테스트 케이스에는 없음)
+                int now = Integer.parseInt(st.nextToken());
+                if (now > h)
+                    continue;
+
+                students[student].add(now);
+                blocks[student][now] = 1;
+            }
+        }
+
+        // 현재 보는 학생의 현재 블록 높이 기준으로 이전 학생의 현황과 비교하여 가능성 기록
+        int before = 1;
+        for (int nowStudent = 2; nowStudent <= n; nowStudent++) {
+            for (int nowBlockHeight : students[nowStudent])
+                for (int candidate = nowBlockHeight; candidate <= h; candidate++)
+                    blocks[nowStudent][candidate] = (blocks[nowStudent][candidate] + blocks[before][candidate - nowBlockHeight]) % 1_0007;
+
+            before = nowStudent;
+        }
+
+        System.out.println(blocks[n][h]);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18eQvQbS5vKq4LqvZR2SxVRlMOju49AiY%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=csnz3Ek)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/18427
시간복잡도 계산 후 dfs로 먼저 접근했습니다
잘못된 계산임을 깨달은 후 dp로 해결했습니다

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/b980356a-7d5d-4f20-bdf0-a02a7a8d49ff)

## 📝 Review Note
```
1초
1억 번 연산

50 * 10 * 1000 = 50_0000

완탐으로 되나?

완탐 먼저 시도
할랬는데 시간초과 기록들이 많은데
일단 시도

그래도 블록 높이별로 정렬하면 덜 탐색할 듯

시간초과 맞는데 왜 시간초과일까


이 문제에서 시간 초과가 발생하는 이유는 주어진 조건과 알고리즘의 동작 방식 때문입니다. 문제의 조건을 다시 한 번 살펴보면, 학생이 최대 50명(N=50)이고, 각 학생이 최대 10개의 블록(M=10)을 가지고 있으며, 탑의 높이가 최대 1000(H=1000)입니다. 이를 해결하기 위해 깊이 우선 탐색(DFS)을 사용하면, 최악의 경우에는 모든 가능한 조합을 탐색하게 되어 연산량이 기하급수적으로 증가할 수 있습니다.
```

그래서 바로 dp로 접근했습니다

![image](https://github.com/user-attachments/assets/0bbd40a1-42de-487a-b3b6-054ad8acbad5)

그런데 자꾸 틀린 답이 나오길래 어떤 부분을 놓쳤을 까 했는데
dp로 무조건 선택하는 것이 아닌 선택하지 않는 경우를 놓쳤었습니다

그리고 첫 제출에서 틀렸다고 나오길래
%10007을 안 했습니다 하하

그럼 숙5링