### PR TITLE
[BOJ]1504. 특정한 최단 경로

### DIFF
--- a/soomin/BOJ_1504.java
+++ b/soomin/BOJ_1504.java
@@ -1,0 +1,106 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class Edge implements Comparable<Edge> {
+    int e, w;
+
+    Edge(int e, int w) {
+        this.e = e;
+        this.w = w;
+    }
+
+    @Override
+    public int compareTo(Edge o) {
+        return w - o.w;
+    }
+}
+
+public class BOJ_1504 {
+
+    static int N, E;
+    static int[][] graph;
+
+    static int INF = 200000000;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+
+        //
+        graph = new int[N + 1][N + 1];
+
+        for (int i = 0; i < E; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            // 양방향
+            graph[s][e] = w;
+            graph[e][s] = w;
+        }
+
+        // 반드시 거쳐야하는 노드
+        st = new StringTokenizer(br.readLine());
+        int must1 = Integer.parseInt(st.nextToken());
+        int must2 = Integer.parseInt(st.nextToken());
+
+
+        int Sto1 = dijkstra(1, must1);
+        int Sto2 = dijkstra(1, must2);
+        int M1toM2 = dijkstra(must1, must2);
+
+
+        if (M1toM2 == INF) { // 꼭 거쳐야하는 노드끼리 연결이 안되어 있으면??
+            System.out.println(-1);
+            return;
+        }
+
+        int M2toE = dijkstra(must2, N);
+        int M1toE = dijkstra(must1, N);
+
+        // s -> 1 -> 2 -> e
+        int result1 = Sto1 + M1toM2 + M2toE;
+        // s -> 2 -> 1 -> e
+        int result2 = Sto2 + M1toM2 + M1toE;
+
+        int result = Math.min(result1, result2);
+        if(result >= INF) result = -1;
+        System.out.println(result);
+    }
+
+    private static int dijkstra(int start, int end) {
+        PriorityQueue<Edge> pq = new PriorityQueue();
+        boolean[] visited = new boolean[N + 1]; // 방문체크
+
+        int[] dist = new int[N + 1]; // 거리
+        Arrays.fill(dist, INF);
+
+        dist[start] = 0; // 시작점 초괴화
+        pq.add(new Edge(start, 0)); // 자기자신
+
+        while (!pq.isEmpty()) {
+            Edge now = pq.poll();
+
+            if (visited[now.e]) continue;
+            visited[now.e] = true;
+
+            for (int i = 1; i <= N; i++) { // 이어진 노드를 차례대로 탐색
+                if (graph[now.e][i] == 0) continue; // 연결 여부
+                if (dist[i] > graph[now.e][i] + dist[now.e]) { // 거리 갱신
+                    dist[i] = graph[now.e][i] + dist[now.e];
+                    pq.add(new Edge(i, dist[i]));
+                }
+            }
+
+        }
+        return dist[end];
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX197DG8sqc8pdcE7R0NV4X0PGmj0ameExac%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=nA_gXjc)
다익스트라

## 👩‍💻 Contents
어제에 이은 다익스트라 문제였슴니다. 복습겸ㅇ로 인지하고 풀었습니당

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/1a551138-424a-4c2d-a9ae-b4a89dedda0a)


## 📝 Review Note
틀린이유는 그러한 경로가 없을 때 예외처리를 제대로 안해서 그랬습니당 하핫

이 문제는 다익스트라 알고리즘을 이용하는데 
결정적으로 두가지 경로를 비교해야합니당 
무조건 지나쳐야하는 정점1, 2가 문제에서 주어지기때문에
시작점 => 1 => 2 => 끝점
시작점 => 2 => 1 => 끝점

이 두가지를 비교해서 가장 최단거리를 구하며 ㄴ됩니다. 그래서 저는 최적화 시켜보고자 1 => 2 부분에서 경로가 없다면 return을 바로 해버렸습니다. 그런데 이거 작성하면서 생각하니 그냥 각 부분 시작 =>1 여기도 INF이면 종료해버려도 될 것 같네여 

감사합니다 우하하...
지난 번엔 인접 리스트로 풀어서 연습해보고자 이번엔 인접행렬로 했는데 인접 리스트가 다익스트라에서 경로 갱신할때 순회하는 횟수가 적어서 더 좋을 것 같다는 생각을 했습니다.

졸리네요 감삼다