### PR TITLE
[BOJ] 6198. 옥상 정원 꾸미기 🏢🏡

### DIFF
--- a/성영준/boj_6198_옥상정원꾸미기.java
+++ b/성영준/boj_6198_옥상정원꾸미기.java
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 스택
+ */
+public class boj_6198_옥상정원꾸미기 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        // 사실상 실 스택을 사용하지 않아도 가능하다
+        // add pop 생략 가능
+        // 속도 줄이는 키 포인트
+        int[] stack = new int[n + 1];
+        // 정답으로 출력할 카운팅 변수
+        long count = 0;
+        // 현재 스택의 커서를 나타내는 수
+        // size 대체 가능
+        int top = 0;
+
+        for (int i = 0; i < n; i++) {
+            int now = Integer.parseInt(br.readLine());
+
+            // 만약 다음 건물이 현재 건물보다 크거나 같다면 제외
+            // 기존의 stack.size() > 0 && stack.peek() <= now 대체
+            while (top > 0 && stack[top] <= now)
+                top--;
+
+            // 현재 높이만큼 더함 (추가되는 건물을 보는 건물은 남은 건물들 만큼임)
+            count += top;
+            // 다음 위치에 건물 정보 저장
+            stack[++top] = now;
+        }
+
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1b2uUVIbzlkchZkr0R7cDjawLIJR9NcU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=GPeyH31)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/6198
스택 문제였습니다

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/84e2cbcb-6d94-4bb7-b8a3-2955d1a13448)

## 📝 Review Note
문제 보자마자 이거 ssafy에서 풀었던 키재기? 랑 비슷한 문제라고 생각해서 알고리즘은stack을 이용한 문제로 금방 떠올렸습니다
하지만 안일하게 빌딩의 높이가 10억으로 int로 충분히 진행될 것이라 판단했었는데
정답으로 출력 되는 변수가 모든 건물이 내림차순으로 내려가는 경우엔 시그마 k = 1 ~ 8만, 79999 * 80000 / 2 인 32억 언저리이기 때문에 long으로 선언해야 했습니다

초기 코드가 진짜 스택을 사용한 코드였는데
해당 코드도 원래 처음에 작성한 코드보다 2배는 분량을 줄이고 효율을 높여서 자신 있게 제출했는데 1등과 속도 차이가 많이 나서 놀랐습니다

이미 많은 고민 끝에 작성한 코드였기에 더 줄이긴 자신 없었고 빠른 사람들의 코드를 참고했습니다

로직은 같지만, 스택을 사용하지 않고 진행하는 것이 포인트였습니다

저는 거기에 -1 연산을 제거한 버전으로 업그레이드 해봤습니다

자세한건 주석에
감사합니다