### PR TITLE
[BOJ]2110. 공유기 설치

### DIFF
--- a/soomin/BOJ_2110.java
+++ b/soomin/BOJ_2110.java
@@ -1,0 +1,69 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_2110 {
+
+    static int N, C;
+    static int[] house;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        house = new int[N];
+        for (int i = 0; i < N; i++) {
+            house[i] = Integer.parseInt(br.readLine());
+        }
+
+        Arrays.sort(house); // 순차적으로 공유기를 설치하기 위함
+
+        // 두 공유기 사이의 거리를 구하기 위한 이분탐색
+        int left = 1;
+        int right = house[N - 1] - house[0] + 1; // 최대 길이는 젤 큰 좌표 - 젤 작은 좌표이나 최대 길이도 탐색에 포함되기 위해서는 +1을 해 탐석범위를 늘려야함. left < right 조건 때문
+
+        while (left < right) {
+
+            int mid = (left + right) / 2;
+
+            if (countWifi(mid) < C) { // mid에 대해 설치 가능한 공유기가 C개보다 작다면 거리를 좁혀야 하기 때문에 right를 감소
+                right = mid;
+            } else { // 거리를 벌리면서 최대 거리를 찾아야함
+                left = mid + 1;
+            }
+
+        }
+
+        System.out.println(left - 1); // left = mid + 1이 되고 탐색이 종료되므로 -1을 해줌
+
+    }
+
+    /**
+     * 두 공유기 사이의 최소 길이가 mid일때 설치할 수 있는 공유기 수를 반환
+     *
+     * @param mid 두 공유기 사이의 길이
+     * @return 설치된 공유기 수
+     */
+    private static int countWifi(int mid) {
+
+        int cnt = 1; // 맨 첫 집은 무조건 설치!
+        int preIdx = house[0]; // 직전에 설치된 좌표를 저장해서 두 공유기 사이의 길이를 구함
+
+        for (int i = 1; i < N; i++) {
+
+            int now = house[i];
+
+            if (now - preIdx >= mid) {
+                cnt++;
+                if(cnt == C) return cnt;
+                preIdx = now;
+            }
+        }
+        return cnt;
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18tMq24UnMfWqBbdvO5FW7or1jaZfhleg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=jhWW0i_)
이분탐색

## 👩‍💻 Contents

https://www.acmicpc.net/problem/2110

이진탐색으로 풀었습니다.

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/f0c69ad1-e0a9-4729-b473-dc11f43bc3ad)


## 📝 Review Note

이진탐색 이유)
간격의 최댓값을 구하기 위해서 늘리거나 줄이면서 주어진 조건대로 공유기를 다 설치할 수 있는지를 파악하면 풀리겠다고 생각했고 이전에 풀었던 [숫자 카드 2](https://www.acmicpc.net/problem/10816) 유사하다고 생각했기에 이분탐색을 떠올렸습니다.

시간 복잡도는 미처 생각하고 풀지 못해 지금 추측해보자면
최대 거리 범위는 1,000,000,000 이고, 
이분탐색은 logN 이걸립니다 (이때 N은 최대 거리 범위)
그리고 공유기 설치가 가능한지 여부를 탐색할 때 N만큼 탐색하니까
```200,000 * log 1,000,000,000 = 6000000 //대략 ```
이렇게 나올 것 같슴다

left와 right를 길이 최솟값과 최댓값으로 두었는데 이때 
최댓값을 집 좌표의 가장 큰값 - 가장 작은 값으로 설정하면 틀립니다.
왜냐하면 저는 이분 탐색의 조건을 left가 right와 같아질때까지 탐색을 하도록 했기 때문입니다. 
left가 right와 같아지는 순간 탐색을 종료하기 때문에 저렇게 하면 최댓값이 탐색 범위에 포함되지 않습니다. 
따라서 최댓값 + 1을 해주어 탐색 범위를 증가했습니다.

만약에 이게 싫다면 while문 조건을 left < right가 아닌 left <= right로 하면 됩니다.

감사합니다.

스스로 풀긴 했지만 로직을 꼼꼼하게 생각하고 코드를 작성하지 않고 로직을 생각하면서 코드를 작성해서 자잘하게 틀렸기 때문에 다시 풀고 싶어서 라벨 하나 만들었씁니다.