### PR TITLE
[BOJ]11053. 가장 긴 증가하는 부분 수열

### DIFF
--- a/soomin/BOJ_11053.java
+++ b/soomin/BOJ_11053.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_11053 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[N];
+        int[] dp = new int[N];
+
+        // 입력
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 0; i<N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+            dp[i] = 1;
+
+            // 부분 수열의 길이를 저장
+            // 해당 인덱스의 수열 원소보다 작은 값이 몇개 인지 탐색하는 반복문
+            for(int j = 0; j<i; j++) {
+                if(arr[j] >= arr[i]) continue;
+
+                int target = dp[j] + 1;
+                if(dp[i] >= target) continue; // 안하면 무조건 값이 갱신되어 최대길이가 보장되지 않는다.
+                dp[i] = target; // 이전 부분수열에 i번째 원소가 추가되었기 때문에 +1
+            }
+        }
+
+        // 최댓길이 구하기
+        int max = 0;
+        for(int i = 0; i<N; i++){
+            max = Math.max(max, dp[i]);
+        }
+
+        System.out.println(max);
+
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18TIqj7KtN11pffhW2COqCmOHNyvHiLg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=s8xw862)
dp

## 👩‍💻 Contents
https://www.acmicpc.net/problem/11053
dp라는 것을 인지하고 문제를 골라 풀었습니다.

2565번 전깃줄(https://www.acmicpc.net/problem/2565)을 푸는데 로직과 알고리즘이 잘 떠오르지 않아서 분류를 확인했고 계속 졸아서 담날에 좀 생각해서 풀고 싶어서 일단 dp인 다른 문제를 골랐습니다. 유유

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/2c5933a7-b052-496b-b003-51742fb75c42)


## 📝 Review Note
dp인걸 알고 문제를 파악했지만 dp인 이유를 생각해봤습니다.

```가장 긴 증가하는 부분 수열을 구할 때, 특정 부분 수열의 길이를 여러번 계산해야할 여지가 있고 이 때문에 dp를 통해서 각 원소를 가진 부분 수열의 길이를 기억해서 풀 수 있는 문제라고 생각했습니다. ```


현재 탐색하는 원소보다 이전 인덱스의 원소들이 마지막으로 포함된 부분 수열의 길이를 비교해 최대길이를 갱신하는 로직을 생각했습니다. 
그래서 시간 복잡도는 i가 N까지 탐색하고 j는  0~i이므로 N*(N-1)입니다. 
N은 최대 1000이므로 1000*999 = 999000이기 때문에 시간제한 1초안입니다.

뭔가 dp를 사용했음에도 약 N2인 시간복잡도가 걸립니다. 이걸 줄이고 싶은데 방법이 지금은 생각이 나지 않습니다. 생각나면 추가해보겠습니다.
