### PR TITLE
[BOJ] 11779. 최소비용 구하기 2

### DIFF
--- a/성영준/boj_11779_최소비용구하기2.java
+++ b/성영준/boj_11779_최소비용구하기2.java
@@ -1,0 +1,130 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/**
+ * 다익스트라 문제
+ */
+public class boj_11779_최소비용구하기2 {
+    /**
+     * 3 가지 용도
+     *  1. 출발 도시부터 도착 도시까지 비용 정보 -> weights 에 저장
+     *      도착 도시
+     *      이동 비용
+     *  2. 시작 도시부터 현재 도시까지 총합 비용 정보 -> pq 에 저장
+     *      다음 도착 도시
+     *      다음 도시까지 이동 총 합 비용
+     *  3. 현재 도시까지 가장 낮은 비용 정보 -> confirmed 에 저장
+     *      현재 도시에 도착하기 이전 도시
+     *      현재 도시까지 이동 총 합 비용
+     */
+    static class Info implements Comparable<Info>{
+        int city;
+        int weight;
+
+        public Info(int city, int weight) {
+            this.city = city;
+            this.weight = weight;
+        }
+
+        @Override
+        public int compareTo(Info o) {
+            return Integer.compare(weight, o.weight);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int m = Integer.parseInt(br.readLine());
+
+        // 출발 도시부터 도착 도시까지 비용 정보
+        // 비용이 0인 경우도 있기에 배열 대신 list 로 진행
+        List<Info>[] weights = new ArrayList[n + 1];
+        for (int i = 1; i <= n; i++)
+            weights[i] = new ArrayList();
+        for (int i = 0; i < m; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+
+            weights[start].add(new Info(end, weight));
+        }
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        // 다익스트라 진행 후 결과 출력
+        System.out.println(dijkstra(weights, start, end, n));
+    }
+
+    /**
+     * 다익스트라를 이용해 출발 도시 부터 도착 도시 까지 최소 비용 계산 하는 메서드
+     * @param weights 출발 도시부터 도착 도시까지 비용 정보
+     * @param start 출발 도시
+     * @param end 도착 도시
+     * @param n 도시의 수
+     * @return 비용, 방문 도시 수, 방문 도시 순서
+     */
+    private static String dijkstra(List<Info>[] weights, int start, int end, int n) {
+        // 시작 도시부터 현재 도시까지 총합 비용 정보
+        Queue<Info> pq = new PriorityQueue<>();
+        // 현재 도시까지 가장 낮은 비용 정보
+        Info[] confirmed = new Info[n + 1];
+
+        // 출발 도시 정보 추가
+        pq.add(new Info(start, 0));
+        confirmed[start] = new Info(-1, 0);
+
+        // 다익스트라 알고리즘
+        while(true) {
+            // 현재 도시가
+            Info now = pq.poll();
+
+            // 도착 도시라면 종료
+            if (now.city == end)
+                break;
+
+            // 아니라면 현재 도시부터 갈 수 있는 다음 도시들 탐색
+            for (Info next : weights[now.city]) {
+                // 다음 도시에 정보가 있는데 더 효율적이라면 스킵
+                int newWeight = now.weight + next.weight;
+                if (confirmed[next.city] != null && confirmed[next.city].weight <= newWeight)
+                    continue;
+
+                // 아니라면 현재 정보 입력
+                // (next.city에는 now.city로 부터 newWeight로 도착 가능하다)
+                confirmed[next.city] = new Info(now.city, newWeight);
+
+                // 후보에 저장
+                // (next.city에는 newWeight로 도착 할 수 있다)
+                pq.add(new Info(next.city, newWeight));
+            }
+        }
+
+        // 정답 출력
+        StringBuilder sb = new StringBuilder();
+        // 도착지의 비용 정보 입력
+        sb.append(confirmed[end].weight).append("\n");
+
+        // 경로 역순회
+        Stack<Integer> stack = new Stack<>();
+        while (end != -1) {
+            stack.add(end);
+
+            end = confirmed[end].city;
+        }
+
+        // 도착지 까지의 경로 수 입력
+        sb.append(stack.size()).append("\n");
+        // 도착지 까지의 경로 입력
+        while (!stack.isEmpty())
+            sb.append(stack.pop()).append(" ");
+
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19qm7qCnQ8Bc5YQImtVnYke9n3sfsVoJYw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=_0x9vtb)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/11779
다익스트라 알고리즘 문제였습니다

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/4a2802f4-7883-42c2-8a8d-a2d347c69841)

## 📝 Review Note
쉬울 줄 알았는데 생각보다 까다로웠습니다

경로를 추적하는 단계를 어떻게 해야 메모리와 시간 적으로 효율적으로 진행할 수 있을까 고민을 많이 했습니다

먼저 1000x1000 이므로 인접 배열로 진행하고
도착지에서부터 역으로 인접 배열을 탐색할 까 생각도 했는데
그건 갔다 오는 과정을 반복하는 것이므로 시간복잡도가 2배 늘어날 뿐 아니라
이동 비용이 0도 포함하기 때문에 배열을 기존에 초기화 작업을 해줘야 하므로 기각했습니다

다음으로 도시 간 이동 비용이 최대 1,000(도시의 수) * 100,000(버스의 수) * 100,000(비용) 이라고 생각해서 long으로 진행했는데
주석을 달며 생각해보니까 최악의 경우가 999(도시의 수) * 100,000(비용) 이더라고요
그래서 int로 추후에 진행해서 메모리를 줄였습니다

이상 다른 방식으로 고민하거나 헤맨 건 없고,
주석에 설명 달아 놨습니다~