### PR TITLE
[BOJ]15651. N과 M(3)

### DIFF
--- a/soomin/BOJ_15651.java
+++ b/soomin/BOJ_15651.java
@@ -1,0 +1,43 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_15651 {
+
+    static int N, M;
+    static int[] list;
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        /*
+         * 백트레킹
+         * 1~N까지의 수 중에서 M개를 선택해서 조합합니다
+         * 중복이 허용되기 때문에 1~N까지 반복문을 돌면 됩니당나귀!
+         */
+        list = new int[M];
+        find(0);
+
+        System.out.println(sb);
+
+    }
+
+    private static void find(int count) {
+        if (count == M) {
+            for(int num : list) sb.append(num).append(" ");
+            sb.append("\n");
+            return;
+        }
+
+        for (int i = 1; i <= N; i++) {
+            list[count] = i;
+            find( count+1);
+        }
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1yDseQg6yhs7jcgHy43EtiFUxWQVDW4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=yvjwRqI)
백트래킹

## 👩‍💻 Contents
https://www.acmicpc.net/problem/15651

예전에 실패한 문제길래 풀어봤습니다. 문제를 읽고 단순한 백트래킹 문제라고 생각해서 20분 타이머 맞추고 풀었습니다.

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/f2d5f183-588e-40f8-aa50-359f4c6f0644)
1등은 126ms? 이래서 줄여보려고 했는데 모르겠습니다. 한 수 알려주세요

## 📝 Review Note
백트래킹이라고 생각한 이유는 모든 가능한 수열을 생성하면서 조건에 맞지 않는 수열을 컷하기 때문입니다. 
하지만 문제에서 컷하는 조건이 수열의 길이 뿐이라서 흠 이게 백트래킹!! 이라고 하기엔 너무 그냥 완전탐색 같긴했는데 아직 백트래킹 더 풀어야할 것 같슴다


쏘 이지한 문제이나 최적화를 어캐 해야할지 감이 안옵니다 how..
처음엔 되도 않게 start 매개변수를 하나두고 중복되지 않을려고 했는데 생각해보니 이 start를 두고 for문을 돌리고 find(count+1, i)해버리면 2,1 같이 첫번째 원소가 두번째 원소보다 큰 경우는 올 수 없으므로 안되는 건데 잘 못 생각해서 이런 것도 생각했다... 예... 그렇슴다

암튼 최적화 힌트 알려주시면 감사합니다. 
