### PR TITLE
[BOJ]2217. 로프

### DIFF
--- a/soomin/BOJ_2217.java
+++ b/soomin/BOJ_2217.java
@@ -1,0 +1,32 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class BOJ_2217 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        int[] rope = new int[N];
+        for (int i = 0; i < N; i++) {
+            rope[i] = Integer.parseInt(br.readLine());
+        }
+
+        Arrays.sort(rope); // 정렬
+
+        /*
+         * 로프의 최소 무게 * 병렬 연결된 로프의 갯수 = 최대 중량이므로
+         * 로프의 최소 무게가 최대가 되어야한다.
+         * 그래서 입력받은 배열을 정렬해서 로프의 무게가 큰 순서대로 탐색하면서
+         * 들어올릴 수 있는 물체의 최대 중량을 구한다
+         */
+        int sum = 0;
+        for (int i = 1; i <= N; i++) { // 배열의 역순으로 참조하기 위해서 1~N까지 탐색합니다. N-i은 인덱스를, i는 병렬 연결된 인덱스르 의미
+            sum = Math.max(sum, rope[N - i] * i); // rope의 무게 * 병렬 연결된 로프의 갯수
+        }
+
+        System.out.println(sum);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX14NXuOoKEUkcAyUeXkzue5mLOwNelX8CI%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=_-VADXZ)
그리디

## 👩‍💻 Contents
https://www.acmicpc.net/problem/2217
그리디 추천문제라고 검색해서 나와서 풀었습니다

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/f73a3fc9-e3ae-4e72-b23e-13b7e48ef277)
타이머 20분 맞추고 풀었슴다

## 📝 Review Note
오늘 문제도 어쩌다보니 쉬운걸 풀게 되었네요 
그리디 문제입니다. 문제를 그리디인걸 알고 풀긴했지만 이건 티가 나는 문제였어요.

결국 선택한 로프들중 최솟값 * 선택된 로프들 갯수 = 최대 중량이기 때문에 로프의 최솟값이 최대가 되어야합니다. 그때문에 ㅏ가장 높은 무게를 버틸 수 있는 로프를 먼저 선택해서 탐색해야하므로 그리디라고 생각합니다.

<최적화를 위한 고민?>
처음에 입력받은 로프의 무게를 내림차순하기 위해서 
`Arrays.sort(rope, Collections.reverseOrder)`를 사용했습니다. 
1등이랑 또 시간차이가 대략 200ms 나길래 
이 부분을 그냥 Arrays.sort(배열)로 바꾸고 인덱스를 가지고 역순으로 참조해 결과가 같게 했습니다. 
그랬더니 시간이 100ms 정도 줄었습니다. 그래서 정리해볼게용

- 1. Arrays.sort(rope) vs Arrays.sort(rope, Collections.reverseOrder())
![image](https://github.com/user-attachments/assets/a9bc2aac-0831-4c04-bf31-0914b979c15e)
이때 후자에서는 내림차순 정렬까지 하니까 추가적인 비교연산이 발생해서 전자가 더 빠르지 않나ㅏ 라는 생각임다

- 2. int 형 vs Integer 형
Collections.reverseOrder를 사용하기 위해서 Integer[]로 배열을 선언했었습니다. 객체이므로 기본 자료형에 비해 비교연산시 시간이 더 소요됩니다.

이런 두가지 이유로 시간이 줄었다고 생각함니다


틀린 설명있으면 알려주시면 thankyou very 감사
티어 안보이는 거 좋네요 난이도가 어떤지 모르니까 좀 더 고민하게 되는 것 같슴다.

![image](https://github.com/user-attachments/assets/feeab6c6-9f49-4a2c-a20f-59b85a4507a7)
