### PR TITLE
[BOJ]11000. 강의실 배정

### DIFF
--- a/soomin/BOJ_11000.java
+++ b/soomin/BOJ_11000.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class Lecture implements Comparable<Lecture>{
+    int s, e;
+    
+    Lecture(int s, int e) {
+        this.s = s;
+        this.e = e;
+    }
+
+
+    @Override
+    public int compareTo(Lecture o) {
+//        if(this.s == o.s) return this.e - o.e; // 시작시간이 같다면 종료 시간으로 오름차순
+        return this.s - o.s; // 시작 시간으로 오름차순
+    }
+}
+
+
+public class BOJ_11000 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N= Integer.parseInt(br.readLine());
+
+        Lecture[] lectures = new Lecture[N]; // 시작시간 순으로 정렬을 편리하게하기 위해서 배열 사용
+        for(int i = 0; i<N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+
+            lectures[i] = new Lecture(s, e);
+        }
+
+        Arrays.sort(lectures); // 시작시간을 기준으로 정렬하여 시작시간이 빠른 순으로 강의실을 채우기 위함
+
+        // 종료 시간을 관리하기 위한 우선순위 큐
+        // Lecture가 아닌 Integer인 이유는 종료시간만 저장하기 때문입니다.
+        // 새로운 강의실을 배정받을지 아니면 새 강의실을 배정받을지 종료시간만으로 판별할 수 잇습니다.
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        pq.offer(lectures[0].e);
+
+        // pq의 가장 작은? 종료시간과 현재 강의의 시작시간을 비교해서
+        // 종료시간을 업데이트 합니다. => 기존 강의의 종료시간보다 시작시간이 크다면 강의실을 재사용 가능하기 때문에 종료시간을 업뎃해줍니다.
+        // 두 번째 강의부터 확인하면서 필요한 강의실 수를 계산
+        for(int i = 1; i<N; i++){
+            if(pq.peek() <= lectures[i].s)  pq.poll(); // 기존 강의실에 삽입하기 위해서 기존 종료시간을 poll한다.
+            pq.offer(lectures[i].e); // 새 강의실 배정
+        }
+
+        System.out.println(pq.size());
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18dRTHxeCRvSFWlLCWJFQ96NusNbK0WZZU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=M5Ib_a7)
그리디, 우선순위 큐

## 👩‍💻 Contents
https://www.acmicpc.net/problem/11000
그리디 더 공부하고 싶어서 백준 그리디 문제들 중에서 골라 풀었습니다.

최근에 본 코테의 3번 문제와 비슷한 것 같아서 재밌게 풀었습니다.

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/e82c57eb-a799-464a-803e-b52da2b89e0a)
2년전에 풀었다면 이미 알고리즘 마스터가 되었을지도...

## 📝 Review Note

처음에 문제를 읽고 생각난 방법은 그냥 완전탐색이었습니다. 하지만 n의 최댓값이 
200,000이므로 시간초과가 무조건 날 것이라고 생각했습니다. (거의 n2아닌가)

어떻게 풀까 고민하다가 시작시간이 빠른 순으로 강의실을 채우되 종료시간을 비교해서 강의실의 갯수를 정하자고 생각했습니다. 그래서 우선순위 큐를 사용하기로 했습니다.

입력값들을 List에 저장할지 배열에 저장할지 고민했는데 딱히 삭제하는 로직이 있는 것도 아니라 배열을 택했습니다. 몇 개가 저장될지 딱 정해져있고 정렬이 조금 더 빠르기 때문입니다. (=> 이걸 쓰면서 느끼는건데 pq를 사용해도 되지 않았을까요? 흠 그럼 입력받는 내내 비교연산이 들어가서 별로인가)

일단 그리고 pq에도 강의의 시작과 끝시간을 저장하는 클래스 lecture를 사용할까했지만 시작시간으로 정렬을 했기 때문에 종료시간만 필요하므로 Integer을 사용했습니다.

주석에도 적어두었습니다. 

그리디인 것을 알고 문제를 풀었기 때문에 그리디인 이유를 추가로 생각해보았습니다. 시간 순서대로 강의를 탐색하면서 기존 강의실을 재사용할 수 있으면 재사용하고 아니면 새 강의실을 사용하는 로직이
매순간 최적의 선택을 하기 때문이라고 생각합니다.
좀 감이 올랑말랑합니다. 


하지만 1등과 또...
200ms 정도 차이가 나는데... 여기서 더 어떻게 줄일 수 있을까유 일단
시작 시간 순으로 오름차순 정렬하고 시작시간이 같다면 종료시간 순으로 오름차순하는 코드가 있었는데
pq에서 종료시간으로 정렬하기 때문에 이부분을 삭제했더니 아주 눈꼽만큼 시간을 축소시킬 수 있었습니다. 또 뭐가 있을까유??

그리디 + 우선순위큐 문제의 기본형이라고 생각해 AGAIN 표시 했습니다. 
긴 글 읽어주셔서 감사합니다.

추추가) 갑자기 강의실의 최소 갯수를 이분탐색으로 구할 수도 있지 않을까 생각이 드는데요 어 왜 그리디로 분류를 햇을까 왜 이분탐색은 비효율적일지  좀 더 고민해보겠습니다.