### PR TITLE
[BOJ]10653. 마라톤2

### DIFF
--- a/soomin/BOJ_10653.java
+++ b/soomin/BOJ_10653.java
@@ -36,16 +36,14 @@ public class BOJ_10653 {
         // 점화식: dp[j][i] = dp[j][i-1] + i-1번째 체크포인트와 i번째 체크포인트의 거리 (i > j)
         // i-1번째 체크포인트까지 j번 건너뛴 상태에서 최솟값 vs i-2번째 체크포인트까지 j-1번 건너뛴 상태에서 최솟값 vs ...
         // 점진적으로 i와 j의 값을 감소시키면서 최솟값을 구합니다.
-        int min;
         for (int i = 1; i < N; i++) { // 첫번째 체크포인트에서 시작하기 때문에 계산할 필요가 없습니다.
             for (int j = 0; j <= K; j++) {
-                min = Integer.MAX_VALUE; // 최솟값을 구하기 위해서 맨 처음 값은 최댓값과 비교한다.
+                dp[j][i] = Integer.MAX_VALUE; // 최솟값을 구하기 위해서 맨 처음 값은 최댓값과 비교한다.
                 for (int k = 0; k <= j; k++) { // k는 i와 j를 감소시키기 위한 변수이다. 건너뛴 횟수에 따라 조정해야하기 때문
                     int index = i - 1 - k;
                     if(index < 0) continue; // points의 배열 범위를 벗어나지 않기 위함임
-                    min = Math.min(dp[j - k][index] + calDistance(points[i], points[index]), min);
+                    dp[j][i] = Math.min(dp[j - k][index] + calDistance(points[i], points[index]), dp[j][i]);
                 }
-                dp[j][i] = min; // 최소 거리를 배열에 저장함다
             }
         }
 

--- a/soomin/BOJ_10653.java
+++ b/soomin/BOJ_10653.java
@@ -1,0 +1,74 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+class Point {
+    int x, y;
+
+    Point(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}
+
+public class BOJ_10653 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        Point[] points = new Point[N]; // 체크포인트 저장하는 배열
+        int[][] dp = new int[K+1][N]; // N번째 체크포인트까지 K번 건너뛰었을 때, 거리의 최솟값을 저장하는 배열
+
+        // 1. 입력
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            points[i] = new Point(x, y);
+        }
+
+        // 2. 메모라이제이션을 이용해 최소 거리를 구하는 과정
+        // 점화식: dp[j][i] = dp[j][i-1] + i-1번째 체크포인트와 i번째 체크포인트의 거리 (i > j)
+        // i-1번째 체크포인트까지 j번 건너뛴 상태에서 최솟값 vs i-2번째 체크포인트까지 j-1번 건너뛴 상태에서 최솟값 vs ...
+        // 점진적으로 i와 j의 값을 감소시키면서 최솟값을 구합니다.
+        int min;
+        for (int i = 1; i < N; i++) { // 첫번째 체크포인트에서 시작하기 때문에 계산할 필요가 없습니다.
+            for (int j = 0; j <= K; j++) {
+                min = Integer.MAX_VALUE; // 최솟값을 구하기 위해서 맨 처음 값은 최댓값과 비교한다.
+                for (int k = 0; k <= j; k++) { // k는 i와 j를 감소시키기 위한 변수이다. 건너뛴 횟수에 따라 조정해야하기 때문
+                    int index = i - 1 - k;
+                    if(index < 0) continue; // points의 배열 범위를 벗어나지 않기 위함임
+                    min = Math.min(dp[j - k][index] + calDistance(points[i], points[index]), min);
+                }
+                dp[j][i] = min; // 최소 거리를 배열에 저장함다
+            }
+        }
+
+        // 3. 마지막으로 dp[][N-1] 중에서 최솟값을 구하기
+        // 마지막 체크포인트에 도달하는 모든 가능한 최솟값이므로 이 중에서 가장 짧은 거리를 탐색해야합니다.
+        // k번 건너뛰기가 반드시 k번을 모두 사용하는 것이 아닌 최대 k번 건너뛸 수 있다는 뜻입니다. 휴 이것 때매 헤맷슴다
+        int answer = dp[0][N-1]; // 건너뛰기를 아예 하지 않은 경우 가장 큰 값을 가지므로 초기값으로 설정
+        for(int i = 1; i<=K; i++) {
+            if(dp[i][N-1] < 0) continue; // 유효하지 않은 경우 건너 뜁니다.
+            answer = Math.min(dp[i][N-1], answer);
+        }
+
+        System.out.println(answer);
+    }
+
+
+    /***
+     * 멘허튼 거리를 구하는 메서드
+     * @param a 체크포인트 A
+     * @param b 체크포인트 B
+     * @return 두 포인트 사이의 거리를 반환
+     */
+    private static int calDistance(Point a, Point b) {
+        return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1yLqdAyGJ6jH43LJzVmCJ8ULG1JH4sjCQ%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=YAWtyNO)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/10653
dp 문제입니다. 

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/4e80e575-24cc-4389-b7d6-05372a9a0631)
헤헤 java 2등햇슴다

## 📝 Review Note
<dp라고 생각한 이유>
첨엔 조합으로 건너뛸 체크포인트를 고르고 건너 뛰었을 때 최솟값을 구해야하나 생각했는데 N이 최대 500개이므로 500CK입니다. 
굉장히 큰 값이 나올 수도 있으므로 패스 했습니다. 그래서 dp라고 생각했습니다. 
메모레이제이션을 사용해서 bottom - top 방법으로 각 체크포인트에서 0~K개의 체크 포인트를 건너뛸 수 있는 경우의 최소거리를 저장해 재사용했슴다

<점화식>
제가 찾은 점화식은 
K가 2고 N이 5일때 아래와 같슴다
1. 4번째 체크 포인트까지 2번 건너 뜀 => 1, 4, 5
2. 3번째 체크 포인트까지 1번 건너 뜀 => 1, 3, 5
3. 2번째 체크 포인트까지 0번 건너 뜀 => 1, 2, 5
이므로 
```dp[i][j] = dp[i][j-1] + j와 j-1 체크포인트 거리 
                 vs dp[i-1][j-2] + j-2와 j의 거리 (i<j 일때)```
입니다.
이를 구현하기 위해서 삼중 포문을 사용했습니다.

<틀린 이유>
N-1과 같은 연산을 줄이려고 
dp 배열과 points 배열의 크기를 N+1 했습니다. 

최솟값을 구할때 탐색범위를 첫번째 체크포인트는 출발지점이기 때문에 굳이 탐색할 필요가 없는데 인덱스 헷갈려서 포함시켰슴다... 헷갈렸어요

그리고 마지막에 한번더 최솟값을 구해야하는데 이 로직을 생각 못하고 하 
시간 버렸습니다. 

K번 건너뛸수 있다고 해서 무조건 K번 건너뛰었을 때 최솟값을 구해야하는 줄 알았는데 최대 K번 건너 뛸 수 있다는 뜻이였습니다. 
계속 틀려서 설마하고 해봤는데 맞았습니다. 
이러면 이거 매개변수 탐색(이분탐색)으로도 풀 수 있을 것 같기두??

감샇바니당