### PR TITLE
[BOJ]1018. 체스판 다시 칠하기

### DIFF
--- a/soomin/BOJ_1018.java
+++ b/soomin/BOJ_1018.java
@@ -1,0 +1,58 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1018 {
+
+    static int N, M;
+    static String[] chess = {"BWBWBWBW", "WBWBWBWB"}; // 왼쪽 상단의 타일이 검정일때, 흰색일때 타일을 문자열 패턴으로 저장해서 비교
+    static String[] map;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // 1. 입력
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new String[N];
+        for(int i = 0; i<N; i++) {
+            map[i] = br.readLine();
+        }
+
+        // 2. 8*8 선택
+        int answer = 501;
+        for(int i = 0; i<= N-8; i++) { // 범위를 벗어나지 않도록 8칸 확보
+            for(int j = 0; j<=M-8; j++) {
+                // 3. 변경할 타일 개수 구하기
+                answer = Math.min(answer, countChangeColor(i, j)); // 시작 위치 (왼쪽 젤 상단 좌표)
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    /**
+     * 왼쪽 젤 상단의 타일색이 검정일때를 기준으로 
+     * 8*8 체스판을 탐색하면서 변경해야할 타일 갯수를 세고 
+     * 검정일 때 변경해야할 갯수와 흰색일 때 변경해야할 갯수를 비교해 최솟값을 반환합니다.
+     * @param y 왼쪽 젤 상단 타일의 행 좌표
+     * @param x 왼쪽 젤 상단 타일의 열 좌표
+     * @return 변경해야할 최소 타일 개수
+     */
+    private static int countChangeColor(int y, int x) {
+        int blackCnt = 0; //검정일 때 변경해야할 타일 개수
+        
+        for(int i = 0; i<8; i++){
+            int row = y + i;
+            for(int j = 0; j<8; j++) {
+                int col = x + j;
+                if(map[row].charAt(col) != chess[i%2].charAt(j)) blackCnt++; // BWBWBWBW과 WBWBWBWB이 반복됨
+            }
+        }
+        return Math.min(blackCnt, 64-blackCnt);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1pTXVexcVGxWdr6T5MVj8Z7Z8kKPdX1mw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=DfahYj9)
브루트포스 알고리즘

## 👩‍💻 Contents
https://www.acmicpc.net/problem/1018
완전탐색으로 풀었습니다. 

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/85a966d3-2400-4b01-b2e7-b74a36685556)


## 📝 Review Note
시간이 2초였고 보드의 최대 크기가 50*50이므로 완전탐색으로 충분하다고 생각했습니다. (42*42*8*8) 

간단한 문제인데 고려할 점은 맨 왼쪽 위 칸이 흰색인 경우, 하나는 검은색인 경우도 비교해서 최소 타일 개수를 구해야함다. 
또 처음에 흰검흰검 번갈아서 나오는 걸 어떻게 확인할지 고민했었습니다. 갯수를 세야하나 하나하나 해야하나 고민하다가 어짜피 8개이니까 문자열로 저장해서 비교했습니당 코드로 보시면 바로 이해하실 수 있을 겁니당

최적화는 흰색인 경우, 검은색인 경우 따로 변경해야할 타일 수를 셌는대 
검은색인 경우만 센다음 `64-변경해야할 타일 수 = 흰색일 경우` 이렇게 구해서 연산을 줄였습니당 

감삼다