### PR TITLE
[BOJ]14500. 테크로미노

### DIFF
--- a/soomin/BOJ_1018.java
+++ b/soomin/BOJ_1018.java
@@ -1,0 +1,58 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1018 {
+
+    static int N, M;
+    static String[] chess = {"BWBWBWBW", "WBWBWBWB"}; // 왼쪽 상단의 타일이 검정일때, 흰색일때 타일을 문자열 패턴으로 저장해서 비교
+    static String[] map;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // 1. 입력
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        map = new String[N];
+        for(int i = 0; i<N; i++) {
+            map[i] = br.readLine();
+        }
+
+        // 2. 8*8 선택
+        int answer = 501;
+        for(int i = 0; i<= N-8; i++) { // 범위를 벗어나지 않도록 8칸 확보
+            for(int j = 0; j<=M-8; j++) {
+                // 3. 변경할 타일 개수 구하기
+                answer = Math.min(answer, countChangeColor(i, j)); // 시작 위치 (왼쪽 젤 상단 좌표)
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    /**
+     * 왼쪽 젤 상단의 타일색이 검정일때를 기준으로 
+     * 8*8 체스판을 탐색하면서 변경해야할 타일 갯수를 세고 
+     * 검정일 때 변경해야할 갯수와 흰색일 때 변경해야할 갯수를 비교해 최솟값을 반환합니다.
+     * @param y 왼쪽 젤 상단 타일의 행 좌표
+     * @param x 왼쪽 젤 상단 타일의 열 좌표
+     * @return 변경해야할 최소 타일 개수
+     */
+    private static int countChangeColor(int y, int x) {
+        int blackCnt = 0; //검정일 때 변경해야할 타일 개수
+        
+        for(int i = 0; i<8; i++){
+            int row = y + i;
+            for(int j = 0; j<8; j++) {
+                int col = x + j;
+                if(map[row].charAt(col) != chess[i%2].charAt(j)) blackCnt++; // BWBWBWBW과 WBWBWBWB이 반복됨
+            }
+        }
+        return Math.min(blackCnt, 64-blackCnt);
+    }
+}

--- a/soomin/BOJ_14500.java
+++ b/soomin/BOJ_14500.java
@@ -9,13 +9,15 @@ public class BOJ_14500 {
     static int[][] paper;
     static int[][] move = {{-1, 0}, {0, 1}, {1, 0}, {0, -1}};
 
+    static int N, M;
+
     public static void main(String[] args) throws IOException {
 
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = new StringTokenizer(br.readLine());
 
-        int N = Integer.parseInt(st.nextToken());
-        int M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
 
         paper = new int[N+2][M+2];
         for(int i = 1; i<=N; i++){
@@ -32,6 +34,8 @@ public class BOJ_14500 {
                 visited[i][j] = true;
                 dfs(i, j, 1, paper[i][j]);
                 visited[i][j] = false;
+
+                otherShape(i, j);
             }
         }
 
@@ -66,11 +70,11 @@ public class BOJ_14500 {
             if(paper[ny][nx] == 0) continue;
             if(visited[ny][nx]) continue;
 
-            if(depth == 2) {
-                visited[ny][nx] = true;
-                dfs(y, x, depth+1, sum+paper[ny][nx]); // ㅑ ㅗ ㅓ ㅜ 튀어나온 부분을 갔다왔다 치고 기존 y, x 좌표에서 다시 상하좌우로 탐색함
-                visited[ny][nx] = false;
-            }
+//            if(depth == 2) {
+//                visited[ny][nx] = true;
+//                dfs(y, x, depth+1, sum+paper[ny][nx]); // ㅑ ㅗ ㅓ ㅜ 튀어나온 부분을 갔다왔다 치고 기존 y, x 좌표에서 다시 상하좌우로 탐색함
+//                visited[ny][nx] = false;
+//            }
 
             visited[ny][nx] = true;
             dfs(ny, nx, depth+1, sum+paper[ny][nx]);
@@ -78,5 +82,26 @@ public class BOJ_14500 {
 
         }
 
+    }
+
+    /**
+     * ㅏ, ㅗ, ㅓ, ㅜ 모양의 최솟값을 바로 구해서 비교
+     * @param y
+     * @param x
+     */
+    private static void otherShape(int y, int x) {
+        // ㅏ, ㅓ, ㅗ, ㅜ 모양을 만들기 위한 4가지 경우
+        if (y > 1 && x > 1 && x <= M - 1) { // ㅓ 모양
+            max = Math.max(max, paper[y][x] + paper[y - 1][x] + paper[y][x - 1] + paper[y][x + 1]);
+        }
+        if (y > 1 && y <= N - 1 && x > 1) { // ㅏ 모양
+            max = Math.max(max, paper[y][x] + paper[y + 1][x] + paper[y - 1][x] + paper[y][x - 1]);
+        }
+        if (y > 1 && y <= N - 1 && x <= M - 1) { // ㅜ 모양
+            max = Math.max(max, paper[y][x] + paper[y - 1][x] + paper[y + 1][x] + paper[y][x + 1]);
+        }
+        if (y <= N - 1 && x > 1 && x <= M - 1) { // ㅗ 모양
+            max = Math.max(max, paper[y][x] + paper[y + 1][x] + paper[y][x - 1] + paper[y][x + 1]);
+        }
     }
 }

--- a/soomin/BOJ_14500.java
+++ b/soomin/BOJ_14500.java
@@ -1,0 +1,82 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_14500 {
+    static boolean[][]  visited;
+    static int max = 0;
+    static int[][] paper;
+    static int[][] move = {{-1, 0}, {0, 1}, {1, 0}, {0, -1}};
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        paper = new int[N+2][M+2];
+        for(int i = 1; i<=N; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j<=M; j++){
+                paper[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // 브루트스 포스
+        visited = new boolean[N+2][M+2];
+        for(int i = 1; i<=N; i++) {
+            for(int j = 1; j<=M; j++) { // 모든 좌표를 탐색 시작 좌표로 설정해서 나올 수 있는 값을 모두 비교
+                visited[i][j] = true;
+                dfs(i, j, 1, paper[i][j]);
+                visited[i][j] = false;
+            }
+        }
+
+        System.out.println(max);
+    }
+
+    /**
+     * dfs로 상하좌우로 인접한 테크로미노를 만들고 최대 값을 구함
+     * 탐색 깊이가 2일 경우 ㅏ, ㅓ, ㅗ, ㅜ 모양을 만들기 위해서
+     * 튀어나온 부분의 값을 더하고 해당 타일이 아닌 기존 타일에서 상하좌우를 탐색하도록
+     * 조건문을 사용해 처리했습니다.
+     *
+     * @param y 좌표
+     * @param x 좌표
+     * @param depth 탐색 깊이 == 개수
+     * @param sum 값의 합
+     */
+    private static void dfs(int y, int x, int depth, int sum) {
+
+        // 기저 조건
+        if(depth == 4) {
+            max = Math.max(sum, max);
+            return;
+        }
+
+        // 상하좌우 인접한 정사각형 탐색
+        // ㅏ ㅗ ㅓ ㅜ 모양을 만들기 위해서 따로 처리해줌
+        for(int d = 0; d<4; d++){
+            int ny = y + move[d][0];
+            int nx = x + move[d][1];
+
+            if(paper[ny][nx] == 0) continue;
+            if(visited[ny][nx]) continue;
+
+            if(depth == 2) {
+                visited[ny][nx] = true;
+                dfs(y, x, depth+1, sum+paper[ny][nx]); // ㅑ ㅗ ㅓ ㅜ 튀어나온 부분을 갔다왔다 치고 기존 y, x 좌표에서 다시 상하좌우로 탐색함
+                visited[ny][nx] = false;
+            }
+
+            visited[ny][nx] = true;
+            dfs(ny, nx, depth+1, sum+paper[ny][nx]);
+            visited[ny][nx] = false;
+
+        }
+
+    }
+}

--- a/soomin/BOJ_14500.java
+++ b/soomin/BOJ_14500.java
@@ -34,8 +34,6 @@ public class BOJ_14500 {
                 visited[i][j] = true;
                 dfs(i, j, 1, paper[i][j]);
                 visited[i][j] = false;
-
-                otherShape(i, j);
             }
         }
 
@@ -70,11 +68,11 @@ public class BOJ_14500 {
             if(paper[ny][nx] == 0) continue;
             if(visited[ny][nx]) continue;
 
-//            if(depth == 2) {
-//                visited[ny][nx] = true;
-//                dfs(y, x, depth+1, sum+paper[ny][nx]); // ㅑ ㅗ ㅓ ㅜ 튀어나온 부분을 갔다왔다 치고 기존 y, x 좌표에서 다시 상하좌우로 탐색함
-//                visited[ny][nx] = false;
-//            }
+            if(depth == 2) {
+                visited[ny][nx] = true;
+                dfs(y, x, depth+1, sum+paper[ny][nx]); // ㅑ ㅗ ㅓ ㅜ 튀어나온 부분을 갔다왔다 치고 기존 y, x 좌표에서 다시 상하좌우로 탐색함
+                visited[ny][nx] = false;
+            }
 
             visited[ny][nx] = true;
             dfs(ny, nx, depth+1, sum+paper[ny][nx]);
@@ -84,24 +82,4 @@ public class BOJ_14500 {
 
     }
 
-    /**
-     * ㅏ, ㅗ, ㅓ, ㅜ 모양의 최솟값을 바로 구해서 비교
-     * @param y
-     * @param x
-     */
-    private static void otherShape(int y, int x) {
-        // ㅏ, ㅓ, ㅗ, ㅜ 모양을 만들기 위한 4가지 경우
-        if (y > 1 && x > 1 && x <= M - 1) { // ㅓ 모양
-            max = Math.max(max, paper[y][x] + paper[y - 1][x] + paper[y][x - 1] + paper[y][x + 1]);
-        }
-        if (y > 1 && y <= N - 1 && x > 1) { // ㅏ 모양
-            max = Math.max(max, paper[y][x] + paper[y + 1][x] + paper[y - 1][x] + paper[y][x - 1]);
-        }
-        if (y > 1 && y <= N - 1 && x <= M - 1) { // ㅜ 모양
-            max = Math.max(max, paper[y][x] + paper[y - 1][x] + paper[y + 1][x] + paper[y][x + 1]);
-        }
-        if (y <= N - 1 && x > 1 && x <= M - 1) { // ㅗ 모양
-            max = Math.max(max, paper[y][x] + paper[y + 1][x] + paper[y][x - 1] + paper[y][x + 1]);
-        }
-    }
 }


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1OgHx5Ym4hD4fFnfNduTSFmn2FdMWFgp0%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=DlzLkrN)

## 👩‍💻 Contents
https://www.acmicpc.net/problem/14500
브루트포스 알고리즘으로 풀었습니다. 최근 코테에 나왔던 문제와 유사하다고 생각해서 선택한 문제입니다(코테에선 조건이 더 있었는데 여긴 단순해서 좀 아쉬웠습니다)

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/d2513e58-e0d4-4cb2-b3ac-f4bc63960323)


## 📝 Review Note
<브루트포스를 선택한 이유>
시간이 2초로 넉넉했고 또 코테와 유사해서 일단 보자마자 dfs로 구현하면 되겠다고 생각했습니다.

<특이사항?>
문제에선 `정사각형 4개를 이어 붙인 폴리오미노는 테트로미노라고 하며, 다음과 같은 5가지가 있다.` 이렇게 나와있는데 제가 오해해서 반드시 4개가 아니라 입력값에 주어지거나 1부터 뭐 다 될 수 있다고 판단해버려서 첨에 좀 너무 어렵게 생각했습니다. ㅋㅋㅋㅋ 졸려서 그런 것 같아요

전체 로직은 금방 구현했는데 ㅏ ㅗ ㅓ ㅜ 를 따로 생각 못하고 코드를 제출해버린 점이 아쉽습니다. 따로 처리를 위해서 조건문을 통해서 튀어나온 부분의 값만 더하고 마저 탐색을 이어나갈 수 있도록 했습니다.

<최적화>
1등과 무려 400ms가 차이가 나서 심각하다 생각했습니다. visited로 방문한 곳 두번 방문하지않도록 하지만 그래도 시간에 영향이 있지 않을까해서 ㅏ ㅗ ㅓ ㅜ 부분을 하드코딩으로 구해버렸습니다. 연산을 줄였다고 생각했는데 유의미하지 않았습니다. ㅜ (코드는 2번째 commit 한 것입니다. )


일단 졸려서 여기까지

