### PR TITLE
[BOJ] 14938. 서강그라운드 (플로이드-워셜, 다익스트라)

### DIFF
--- a/성영준/boj_14938_서강그라운드.java
+++ b/성영준/boj_14938_서강그라운드.java
@@ -1,10 +1,24 @@
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Arrays;
-import java.util.StringTokenizer;
+import java.util.*;
 
 public class boj_14938_서강그라운드 {
+    static class Node implements Comparable<Node> {
+        int target;
+        int distance;
+
+        public Node(int target, int distance) {
+            this.target = target;
+            this.distance = distance;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return distance - o.distance;
+        }
+    }
+
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = new StringTokenizer(br.readLine());
@@ -19,11 +33,9 @@ public class boj_14938_서강그라운드 {
             itemCounts[i] = Integer.parseInt(st.nextToken());
         }
 
-        int maxDistance = 15 * 100;
-        int[][] distances = new int[n + 1][n + 1];
+        List<Node>[] distances = new ArrayList[n + 1];
         for (int i = 1; i <= n; i++) {
-            Arrays.fill(distances[i], maxDistance);
-            distances[i][i] = 0;
+            distances[i] = new ArrayList<>();
         }
         for (int i = 0; i < r; i++) {
             st = new StringTokenizer(br.readLine());
@@ -32,32 +44,43 @@ public class boj_14938_서강그라운드 {
             int b = Integer.parseInt(st.nextToken()); // 지역 b
             int l = Integer.parseInt(st.nextToken()); // 길의 길이
 
-            distances[a][b] = l;
-            distances[b][a] = l;
-        }
-
-        for (int target = 1; target <= n; target++) {
-            for (int start = 1; start <= n; start++) {
-                for (int end = 1; end <= n; end++) {
-                    int newWay = distances[start][target] + distances[target][end];
-                    if (distances[start][end] > newWay) {
-                        distances[start][end] = newWay;
-                    }
-                }
-            }
+            distances[a].add(new Node(b, l));
+            distances[b].add(new Node(a, l));
         }
 
         int answer = 0;
-        for (int start = 1; start <= n; start++) {
-            int total = 0;
-            for (int end = 1; end <= n; end++) {
-                if (distances[start][end] <= m) {
-                    total += itemCounts[end];
-                }
-            }
-            answer = Math.max(answer, total);
+        for (int i = 1; i <= n; i++) {
+            answer = Math.max(answer, djikstra(i, n, m, distances, itemCounts));
         }
 
         System.out.println(answer);
+    }
+
+    private static int djikstra(int start, int n, int m, List<Node>[] distances, int[] itemCounts) {
+        boolean[] visited = new boolean[n + 1];
+
+        Queue<Node> pq = new PriorityQueue<>();
+        pq.add(new Node(start, 0));
+
+        int total = 0;
+        while (!pq.isEmpty()) {
+            Node now = pq.poll();
+
+            if (visited[now.target])
+                continue;
+            visited[now.target] = true;
+
+            total += itemCounts[now.target];
+
+            for (Node next : distances[now.target]) {
+                int newDistance = now.distance + next.distance;
+                if (newDistance > m)
+                    continue;
+
+                pq.add(new Node(next.target, newDistance));
+            }
+        }
+
+        return total;
     }
 }

--- a/성영준/boj_14938_서강그라운드.java
+++ b/성영준/boj_14938_서강그라운드.java
@@ -1,0 +1,63 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class boj_14938_서강그라운드 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken()); // 지역 개수
+        int m = Integer.parseInt(st.nextToken()); // 수색범위
+        int r = Integer.parseInt(st.nextToken()); // 길의 개수
+
+        st = new StringTokenizer(br.readLine());
+        int[] itemCounts = new int[n + 1];
+        for (int i = 1; i <= n; i++) {
+            itemCounts[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int maxDistance = 15 * 100;
+        int[][] distances = new int[n + 1][n + 1];
+        for (int i = 1; i <= n; i++) {
+            Arrays.fill(distances[i], maxDistance);
+            distances[i][i] = 0;
+        }
+        for (int i = 0; i < r; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int a = Integer.parseInt(st.nextToken()); // 지역 a
+            int b = Integer.parseInt(st.nextToken()); // 지역 b
+            int l = Integer.parseInt(st.nextToken()); // 길의 길이
+
+            distances[a][b] = l;
+            distances[b][a] = l;
+        }
+
+        for (int target = 1; target <= n; target++) {
+            for (int start = 1; start <= n; start++) {
+                for (int end = 1; end <= n; end++) {
+                    int newWay = distances[start][target] + distances[target][end];
+                    if (distances[start][end] > newWay) {
+                        distances[start][end] = newWay;
+                    }
+                }
+            }
+        }
+
+        int answer = 0;
+        for (int start = 1; start <= n; start++) {
+            int total = 0;
+            for (int end = 1; end <= n; end++) {
+                if (distances[start][end] <= m) {
+                    total += itemCounts[end];
+                }
+            }
+            answer = Math.max(answer, total);
+        }
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18VeHqzF6MVpxrMeSp61TTFArbBM2dW74%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=wA7H7ez)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/14938

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/1beb0c5c-d596-42e3-aca3-20c820fdfac4)


## 📝 Review Note
문제 뭐 풀까 돌아다니다가
![image](https://github.com/user-attachments/assets/ab72ffbb-b756-4657-add3-9e8c96744899)
solved.ac에 class나 올려볼까 하다 찾았습니다

문제가 배틀그라운드와 유사하게 설명을 시작해서 글이 눈에 쏙쏙 들어왔습니다
제가 난독증이 있는 게 아니고, 관심 있는 분야는 머리에 순식간에, 없는 분야는 철통 봉쇄 하나봅니다

보자마자 떠오른건
1. 다익스트라다
2. 플로이드-워셜도 된다

입니다

근데 꼭두새벽이라 2번을 떠올리며 자연스래 1번은 사라졌고
바로 플로이드-워셜로 풀어보았습니다

생각보다 쉬웠으나
그렇게 하니 80ms가 나오고
1등은 68ms인 걸 확인했습니다

이유가 뭘까 분석하다가
맨 처음에 다익스트라를 떠올렸던 걸 기억했습니다

문제가 탐색범위를 벗어난 경우는 보지 않아도 되기에
플로이드 워셜로 할 경우는
지금 현재 탐색 장소가 탐색범위를 벗어났다고 해서
다음 탐색 장소가 탐색범위를 벗어난다는 보장이 없기에
탐색범위가 좁을경우에도 전체를 다 봐야 한다는 비효율적인 부분이 생깁니다

그래서 다익스트라를 이용한다면
한 정점으로부터 출발해서, 다음 정점까지 거리가 탐색범위를 벗어난다?
그럼 안 넣으면 그만입니다

그렇게 코드 작성하면 그만입니다

![image](https://github.com/user-attachments/assets/b968de79-b9e0-44b3-9cc0-13a59fb247f7)
또 1등인 겁니다

뿌듯합니다 ㅋ