### PR TITLE
[BOJ] 2015. 수들의 합 4

### DIFF
--- a/성영준/boj_2015_수들의합4.java
+++ b/성영준/boj_2015_수들의합4.java
@@ -1,0 +1,33 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class boj_2015_수들의합4 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(0, 1);
+
+        long answer = 0;
+        int total = 0;
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            total += Integer.parseInt(st.nextToken());
+
+            answer += map.getOrDefault(total - k, 0);
+
+            map.put(total, map.getOrDefault(total, 0) + 1);
+        }
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18iC69IPMwCUZJ7EVJVDpOKQ7eco5GTfYM%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=9787h5V)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/2015

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/f10a32ac-afb9-405f-b0d2-3d875a43d588)


## 📝 Review Note
보자마자 누적합이라는건 깨달았습니다
그리고 해당 누적합을 구한 순간에 다른 자료구조에 k 만큼 더한 값을 저장하는 로직도 생각했습니다

그런데 문제를 보니 더해서 나오는 값의 범위가 20억까지 나오게 되고
int 배열을 20억 크기만큼 선언한다면 메모리가 128기가로 128메가보다 훨씬 높은 크기가 나오게 되어 고민 좀 했습니다
그래서 당연히 map도 안되겠구나 했는데

크기는 20억까지지만 가짓수는 20만이므로 map으로 하면 됐습니다

그리고 범위를 보고 20억 까지니까 범위초과는 없겠거니 하고 제출했는데 틀려서 한참 봤는데
만약 누적값에서 k만큼 뺄 때, 누적 값이 -20억이고 k가 20억이면 -40억이 나오므로 초과가 되어 틀리는 것이었습니다

![image](https://github.com/user-attachments/assets/66c5dbeb-09cc-49bd-b8ed-1062bfec218d)
4등 달성!

제출이 많은 건 상위 코드를 확인하다가

```
        private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
```
이 부분을 확인해서

```
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
```
이거 보다 빠른가? 싶어서 테스트 해봤는데 차이는 없었습니다
코드는 깔끔하게 보이는데 코테에 저거 할 시간이 없을 것 같아서 그냥 안 쓰려고요