### PR TITLE
[BOJ] 7453. 합이 0인 네 정수

### DIFF
--- a/성영준/boj_7453_합이0인네정수.java
+++ b/성영준/boj_7453_합이0인네정수.java
@@ -1,0 +1,86 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class boj_7453_합이0인네정수 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[][] arrays = new int[4][n];
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            for (int j = 0; j < 4; j++) {
+                arrays[j][i] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int[][] halfArrays = new int[2][n * n];
+        for (int i = 0; i < n; i++) {
+            int num = n * i;
+            for (int j = 0; j < n; j++) {
+                halfArrays[0][num + j] = arrays[0][i] + arrays[1][j];
+                halfArrays[1][num + j] = arrays[2][i] + arrays[3][j];
+            }
+        }
+
+        Arrays.sort(halfArrays[0]);
+        Arrays.sort(halfArrays[1]);
+
+        System.out.println(process(n, halfArrays));
+    }
+
+    private static long process(int n, int[][] arrays) {
+        long answer = 0;
+
+        int right = n * n - 1;
+        for (int now : arrays[0]) {
+            right = binarySearchRight(right, -now, arrays[1]);
+
+            if (-now == arrays[1][right]) {
+                int left = binarySearchLeft(right, -now, arrays[1]);
+                answer += right - left + 1;
+            }
+        }
+
+        return answer;
+    }
+
+    private static int binarySearchRight(int right, long criteria, int[] array) {
+        int left = 0;
+        int match = right;
+
+        while (left <= right) {
+            int mid = (left + right) >> 1;
+
+            if (array[mid] > criteria)
+                right = mid - 1;
+            else {
+                left = mid + 1;
+                if (array[mid] == criteria)
+                    match = mid;
+            }
+        }
+
+        return match;
+    }
+
+    private static int binarySearchLeft(int right, long criteria, int[] array) {
+        int left = 0;
+
+        while (left < right) {
+            int mid = (left + right) >> 1;
+
+            if (array[mid] < criteria)
+                left = mid + 1;
+            else
+                right = mid;
+        }
+
+        return left;
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1auDTFIq4h9bvoGCz9Wv5Jh5jQA1Pqs%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=38N4mFk)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/7453

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/67314596-b1ed-4bf4-96da-507522229b73)
![image](https://github.com/user-attachments/assets/b11f9d1e-02c5-4fb6-9743-d0d990b82a39)

## 📝 Review Note
접근이 다양했습니다
일단 배열을 4칸짜리를 n개 받는 것이 아니고 n칸짜리를 4개 받는 것으로 하는 건 모두 동일합니다

1. 1, 2번 배열만 정렬
![image](https://github.com/user-attachments/assets/8837c4cb-2f08-427e-8cfb-9157a39c0a3b)
이 방법은 3중 for문을 이용하는 것입니다
먼저 3번과 4번을 2중 for문을 통해 합을 구합니다
그리고 2번을 순회하며 1번은 binarySearch로 찾는 것입니다
이때 찾은 1번의 위치가 다음 2번 배열의 값에 대해 찾을 범위의 최대입니다
(2번 배열의 첫 값과 대응 하는 값을 binarySearch로 찾을 때, 처음에는 전체 범위에서 탐색
이때 나온 1번 배열의 위치가, 다음 2번 배열의 값에 대한 1번 배열에서 값 위치를 찾을 최대 범위로 사용)

하지만 이 경우는 4,000 * 4,000 * 4,000 * 루트4,000 이므로 12억 연산을 넘어서는 방식이었습니다

2. 1, 2번 배열의 모든 합의 경우를 구한 배열, 3, 4번 배열의 모든 합의 경우를 구한 배열
![image](https://github.com/user-attachments/assets/9c82f858-2601-4b2f-a586-a32d587d9c39)
두 배열에서 나올 수 있는 모든 배열 합의 경우를 미리 구하는 것입니다
그리고 양쪽을 모두 정렬하여 한쪽의 값을 다른 쪽에서 이진탐색을 통해 찾는 것입니다
하지만 해당 방식은 같은 값이 여러 개 나올 경우를 대비하지 못해서 틀렸습니다

이에 대한 해결책이 뭘까
여기서 이제 오래 걸렸습니다
2-1. 그럼 이진탐색으로 찾은 그 숫자에서 아래 위로 범위를 찾아 곱하면 되는 거 아닌가?
이 방식은 그럼 이진탐색을 적어도 2번을 해야 해서 느리다고 판단했습니다
2-2. 그럼 map에다가 해당 값의 수를 기록해 놓고, 정렬된 key를 이진탐색하면 안되나?
이 방식은 어제 풀었던
https://github.com/JaMongDan/rehabilitation_algorithm/pull/303
이 문제에서 사용한 기억도 있기도 하고, map의 경우 단번에 찾으니 빠르지 않을까? getOrDefault가 있지만 빠르지 않을까? 해서 채택했습니다

일단 이진탐색부터 틀렸습니다 map인데 굳이 이진탐색할 필요가 없었습니다
그리고 getOrDefault가 느린 것이 맞았습니다

그럼 방법이 없나 했는데
@kdozlo 씨가 스포한 바로 2-1의 방법대로 하면 되는 거였습니다

근데 그 과정도 생각보다 쉽지 않았습니다
`아래 위로 범위를 찾아 곱하면 되는 거 아닌가?`
아 이거 쉽지 않았습니다
![image](https://github.com/user-attachments/assets/116e2ae1-05fb-41fb-ad82-ff99858a4cab)
![image](https://github.com/user-attachments/assets/5169e45f-e18e-435d-a150-cf130b48c07b)
![image](https://github.com/user-attachments/assets/b25f541b-71d4-4db8-9101-c3dd027ffcfc)
엄청 분석했습니다
맨 아래 값을 찾는 건 익숙하게 잘 만들었는데
맨 위 값을 찾는 건 예전에 만든 기억도 있는데 좀 오래걸렸습니다

그런데 여기서 의문인 게
제가 만든 최상위 수를 찾는 방식과
크도즐로씨가 만든 최상위 수를 찾는 방식이 다른데
저 코드를 제꺼에 삽입하면 자꾸 틀린다는 것입니다
먼저 코드 보겠습니다

```
    public static int upperBound(int target) {
        int start = 0;
        int end = nn;

        while (start < end) {
            int mid = (start + end) / 2;

            if (cdl[mid] > target) {
                end = mid;
            } else {
                start = mid + 1;
            }
        }

        return start;
    }
```
이게 크도즐로씨 꺼고요

```
    private static int binarySearchRight(int right, long criteria, int[] array) {
        int left = 0;
        int match = right;

        while (left <= right) {
            int mid = (left + right) >> 1;

            if (array[mid] > criteria)
                right = mid - 1;
            else {
                left = mid + 1;
                if (array[mid] == criteria)
                    match = mid;
            }
        }

        return match;
    }
```
이게 제껍니다

김머영씨꺼는 이제 최상위 위치의 바로 윗 칸을 찾는 방식이고
저는 최상위 위치를 찾는 방식입니다

이 부분은 그냥 찾은 후 +1을 하나 넣냐 마냐 차이인데
저 코드를 제꺼에 넣으면 자꾸 틀립니다 흑흑

이유 찾아주새우~
물론 할 사람 없겠지만 언젠가 누가 리뷰 해주면 좋겠다람쥐
코드도 저렇게 친절하게 다 올렸는데