### PR TITLE
[BOJ] 1446. 지름길

### DIFF
--- a/성영준/boj_1446_지름길.java
+++ b/성영준/boj_1446_지름길.java
@@ -1,0 +1,79 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class boj_1446_지름길 {
+    static class Info implements Comparable<Info> {
+        int destination;
+        int cost;
+
+        public Info(int destination, int cost) {
+            this.destination = destination;
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo(Info o) {
+            return cost - o.cost;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken()); // 길 수
+        int d = Integer.parseInt(st.nextToken()); // 도착지
+
+        Map<Integer, List<Info>> map = new HashMap<>();
+        TreeSet<Integer> spots = new TreeSet<>();
+        spots.add(0);
+        spots.add(d);
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int s = Integer.parseInt(st.nextToken()); // 시작
+            int e = Integer.parseInt(st.nextToken()); // 끝
+            int l = Integer.parseInt(st.nextToken()); // 길이
+
+            if (s >= d || e > d)
+                continue;
+
+            spots.add(s);
+            spots.add(e);
+
+            List<Info> pq = map.getOrDefault(s, new ArrayList<>());
+            pq.add(new Info(e, l));
+            map.put(s, pq);
+        }
+
+        int prev = spots.pollFirst();
+        while (!spots.isEmpty()) {
+            int next = spots.pollFirst();
+
+            List<Info> pq = map.getOrDefault(prev, new ArrayList<>());
+            pq.add(new Info(next, next - prev));
+            map.put(prev, pq);
+            prev = next;
+        }
+
+        System.out.println(process(d, map));
+    }
+
+    private static int process(int d, Map<Integer, List<Info>> map) {
+        Queue<Info> pq = new PriorityQueue<>();
+        pq.add(new Info(0, 0));
+
+        while (true) {
+            Info now = pq.poll();
+
+            if (now.destination == d)
+                return now.cost;
+
+            for (Info next : map.get(now.destination)) {
+                pq.add(new Info(next.destination, next.cost + now.cost));
+            }
+        }
+    }
+}

--- a/성영준/boj_1446_지름길.java
+++ b/성영준/boj_1446_지름길.java
@@ -26,7 +26,7 @@ public class boj_1446_지름길 {
         int n = Integer.parseInt(st.nextToken()); // 길 수
         int d = Integer.parseInt(st.nextToken()); // 도착지
 
-        Map<Integer, List<Info>> map = new HashMap<>();
+        Map<Integer, Map<Integer, Integer>> map = new HashMap<>();
         TreeSet<Integer> spots = new TreeSet<>();
         spots.add(0);
         spots.add(d);
@@ -43,25 +43,35 @@ public class boj_1446_지름길 {
             spots.add(s);
             spots.add(e);
 
-            List<Info> pq = map.getOrDefault(s, new ArrayList<>());
-            pq.add(new Info(e, l));
-            map.put(s, pq);
+            Map<Integer, Integer> spot = map.getOrDefault(s, new HashMap<>());
+
+            if (spot.containsKey(e) && spot.get(e) <= l)
+                continue;
+
+            spot.put(e, l);
+            map.put(s, spot);
         }
 
         int prev = spots.pollFirst();
         while (!spots.isEmpty()) {
             int next = spots.pollFirst();
 
-            List<Info> pq = map.getOrDefault(prev, new ArrayList<>());
-            pq.add(new Info(next, next - prev));
-            map.put(prev, pq);
+            int commonLength = next - prev;
+
+            Map<Integer, Integer> spot = map.getOrDefault(prev, new HashMap<>());
+
+            if (!spot.containsKey(next) || spot.get(next) > commonLength) {
+                spot.put(next, commonLength);
+                map.put(prev, spot);
+            }
+
             prev = next;
         }
 
         System.out.println(process(d, map));
     }
 
-    private static int process(int d, Map<Integer, List<Info>> map) {
+    private static int process(int d, Map<Integer, Map<Integer, Integer>> map) {
         Queue<Info> pq = new PriorityQueue<>();
         pq.add(new Info(0, 0));
 
@@ -71,8 +81,10 @@ public class boj_1446_지름길 {
             if (now.destination == d)
                 return now.cost;
 
-            for (Info next : map.get(now.destination)) {
-                pq.add(new Info(next.destination, next.cost + now.cost));
+            Map<Integer, Integer> nextMap = map.get(now.destination);
+            Set<Integer> keySet = nextMap.keySet();
+            for (int next : keySet) {
+                pq.add(new Info(next, nextMap.get(next) + now.cost));
             }
         }
     }


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1UPkgPN4gZoHPX1idC5zDEWMab78mr20%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=4shdj83)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/1446

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/67781fd2-e28f-4085-8f6f-0e7c69357908)


## 📝 Review Note
다익스트라 풀어봤습니다

지름길의 도착지가 아닌 경우는 1만큼 시간이 소요되고,
맞는 경우가 생각해봐야 할 문제입니다

그리고 도착지가 도로길이보다 길다면 시작지도 고려할 필요가 없어집니다

따라서 각 지점마다 지름길 정보를 저장하고,
각 지점마다 잇는 길 정보를 저장하고,
다익스트라 해주면 됩니다

![image](https://github.com/user-attachments/assets/93836d7d-9413-4a44-bc25-29ab0596918c)
그런데
dp로 푸는 게 더 빠르네요

![image](https://github.com/user-attachments/assets/34ee309e-7d5e-4f56-b11a-7ca0c12377f7)
그리고 리뷰 적다가 생각나서 중복 제거를 해보았더니 더 빨라졌습니다
아마 dp와 이 방법이 테스트케이스에 따라 이점이 다를거라 생각합니다

dp는 기본적으로 pq에서 넣고 뺴는 시간이 없기 때문에 끝까지 간다면 더 빠르겠지만
만약 초기 지름길이 정답이 되는 경우가 있다면 다익스트라가 빠를것입니다

그래서 중간에 지름길이 나온다는 가정하에는 두 코드가 비슷하게 속도가 나올 것 같습니다