### PR TITLE
[BOJ]9935. 문자열 폭발 

### DIFF
--- a/soomin/BOJ_9935.java
+++ b/soomin/BOJ_9935.java
@@ -4,11 +4,16 @@ import java.io.InputStreamReader;
 import java.util.Stack;
 
 public class BOJ_9935 {
+
+    static int len;
+
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
         String str = br.readLine();
         String explosion = br.readLine();
+
+        len = explosion.length();
 
         // 모든 폭발 문자열이 폭발
         // 남은 문자열을 순서대로 이어 붙여서 새로운 문자열을 만듬
@@ -20,12 +25,12 @@ public class BOJ_9935 {
         for (int i = 0; i < str.length(); i++) {
             stack.push(str.charAt(i));
 
-            if (stack.size() < explosion.length()) continue;
+            if (stack.size() < len) continue;
 
             boolean flag = isSame(explosion, stack);
 
             if (flag) {
-                for (int j = 0; j < explosion.length(); j++) { // 폭발 문자열 제거
+                for (int j = 0; j < len; j++) { // 폭발 문자열 제거
                     stack.pop();
                 }
             }
@@ -45,8 +50,10 @@ public class BOJ_9935 {
     private static boolean isSame(String explosion, Stack<Character> stack) {
         boolean flag = true;
 
+        // 스택의 마지막 부분을 폭발 문자열과 비교
+        // 스택의 끝에서부터 폭발 문자열 길이만큼을 순회하며 각 문자가 일치하는 지 확인한다.
         for (int j = 0; j < explosion.length(); j++) {
-            if (stack.get(stack.size() - explosion.length() + j) != explosion.charAt(j)) {
+            if (stack.get(stack.size() -len + j) != explosion.charAt(j)) { // 스택의 마지막 N(폭발 문자열의 길이)개의 요소를 폭발 문자열과 순서대로 비교
                 flag = false;
                 break; // 폭발 문자열과 다르면 종료
             }

--- a/soomin/BOJ_9935.java
+++ b/soomin/BOJ_9935.java
@@ -1,0 +1,56 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class BOJ_9935 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String str = br.readLine();
+        String explosion = br.readLine();
+
+        // 모든 폭발 문자열이 폭발
+        // 남은 문자열을 순서대로 이어 붙여서 새로운 문자열을 만듬
+        // 새로운 문자열에도 폭발 문자열이 포함 되어있을 수 있음
+        // 더이상 폭발하지 않을 때까지 반복한다.
+
+        // 스택을 사용할거임
+        Stack<Character> stack = new Stack<>();
+        for (int i = 0; i < str.length(); i++) {
+            stack.push(str.charAt(i));
+
+            if (stack.size() < explosion.length()) continue;
+
+            boolean flag = isSame(explosion, stack);
+
+            if (flag) {
+                for (int j = 0; j < explosion.length(); j++) { // 폭발 문자열 제거
+                    stack.pop();
+                }
+            }
+
+        }
+
+        // 출력
+        if (stack.isEmpty()) System.out.println("FRULA");
+        else {
+            StringBuilder sb = new StringBuilder();
+            while (!stack.isEmpty()) sb.append(stack.pop());
+            System.out.println(sb.reverse());
+        }
+    }
+
+    // 폭발 문자열과 동일한지 비교하는 함수
+    private static boolean isSame(String explosion, Stack<Character> stack) {
+        boolean flag = true;
+
+        for (int j = 0; j < explosion.length(); j++) {
+            if (stack.get(stack.size() - explosion.length() + j) != explosion.charAt(j)) {
+                flag = false;
+                break; // 폭발 문자열과 다르면 종료
+            }
+        }
+        return flag;
+    }
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1cDYwMWBNsSdGkDSbMGx8Rdlg6YhwpFiQ%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=fGze_H8)
## 👩‍💻 Contents
https://www.acmicpc.net/problem/9935

스택으로 풀었습니다.

## 📱 Screenshot
![image](https://github.com/user-attachments/assets/bb7d68a9-6996-4427-9245-775a667eac96)


## 📝 Review Note
스택을 생각하게 된 이유는 처음에는 단순 구현으로 문자열에 폭발 문자열이 존재하는 지 확인하고 제거해주는 걸 반복하려고 했는데 이렇게하면 자료구조를 뭘로할까 고민을 하다가 스택을 사용하면 되겠다고 생각했습니다.
그런데 스택을 사용하면 굳이 단순 구현 방법말고 처음부터 폭발 문자열을 제거하고 삽입하면 될 것 같았슴니다

그래서 로직은

스택에 문자열의 문자를 하나씩 넣다가
1) 만약 폭발 문자열보다 스택의 길이가 크거나 같다면 폭발 문자열과 동일한지 비교합니다.
2) 비교해서 같다면 stack에서 폭발 문자열을 제거합니다. 
3) 다르다면 넘어갑니다


끝@@!!
1등과 시간차이가 많이 나는데 아마 마지막에 스택에서 pop을 하고 reverse를 해서 긴 것 같슴다 
김대영씨 코드를 구경했는데 애초에 스택이 아니라 StringBuilder를 사용해서 reverse를 안하도록 했더라구요 아주 스마트 하십니다